### PR TITLE
fix(azure-openai): api-key header

### DIFF
--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/azureopenai.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/azureopenai.scala
@@ -137,7 +137,7 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, apikey:
     env.Ws
       .url(url)
       .withHttpHeaders(
-        "Authorization" -> s"api-key ${apikey}",
+        "api-key" -> apikey,
         "Accept" -> "application/json",
       ).applyOnWithOpt(body) {
         case (builder, body) => builder
@@ -190,7 +190,7 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, apikey:
     env.Ws
       .url(url)
       .withHttpHeaders(
-        "Authorization" -> s"api-key ${apikey}",
+        "api-key" -> apikey,
         "Accept" -> "application/json",
       ).applyOnWithOpt(body) {
         case (builder, body) => builder


### PR DESCRIPTION
This pull request fixes an issue with the API Key header for Azure OpenAI.

Reference : https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#request-header
Example : https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=keyless%2Ctypescript-keyless%2Cpython-new%2Ccommand-line&pivots=rest-api

``` bash
curl $AZURE_OPENAI_ENDPOINT/openai/deployments/gpt-35-turbo/chat/completions?api-version=2024-02-01 \
  -H "Content-Type: application/json" \
  -H "api-key: $AZURE_OPENAI_API_KEY" \
  -d '{"messages":[{"role": "system", "content": "You are a helpful assistant."},{"role": "user", "content": "Does Azure OpenAI support customer managed keys?"},{"role": "assistant", "content": "Yes, customer managed keys are supported by Azure OpenAI."},{"role": "user", "content": "Do other Azure AI services support this too?"}]}'
```