### PR TITLE
move to scala 3, play 3, pekko

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,11 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup jdk17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 17
       - uses: sbt/setup-sbt@v1.1.5
       - uses: coursier/cache-action@v6
@@ -27,15 +28,15 @@ jobs:
           SBT_OPTS: -Xmx8G -Xss32M
         run: |
           sbt ';compile;package;assembly'
-          rm ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar 
-          mv ./target/scala-2.12/otoroshi-llm-extension-assembly_2.12-dev.jar ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar
+          rm ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar 
+          mv ./target/scala-3.8.4/otoroshi-llm-extension-assembly_3-dev.jar ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar
       - name: Generate SHA-256
         run: |
-          shasum -a 256 ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar | cut -d ' ' -f 1 > ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar.sha256
+          shasum -a 256 ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar | cut -d ' ' -f 1 > ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar.sha256
       - name: Release binary and SHA-256 checksum to GitHub
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.version }}
           files: |
-            ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar
-            ./target/scala-2.12/otoroshi-llm-extension_2.12-${{ inputs.version }}.jar.sha256
+            ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar
+            ./target/scala-3.8.4/otoroshi-llm-extension_3-${{ inputs.version }}.jar.sha256

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 Otoroshi LLM Extension is a set of Otoroshi plugins for building an AI/LLM gateway. It provides a unified interface to 20+ LLM providers with features like load balancing, fallbacks, semantic caching, guardrails, and budget management.
 
-**Requirements**: JDK 17+ and Scala 2.12
+**Requirements**: JDK 17+ and Scala 3.8.4
 
 ## Build Commands
 
@@ -20,9 +20,12 @@ sbt test
 # Run a single test suite
 sbt "testOnly com.cloud.apim.otoroshi.extensions.aigateway.ProvidersSuite"
 
+# Run only the suites that do not need a real LLM provider
+sh ./scripts/run-offline-tests.sh
+
 # Build fat JAR for deployment
 sbt assembly
-# Output: target/scala-2.12/otoroshi-llm-extension-assembly_2.12-dev.jar
+# Output: target/scala-3.8.4/otoroshi-llm-extension-assembly_3-dev.jar
 ```
 
 ## Architecture
@@ -77,7 +80,7 @@ Test configuration uses `domains/providers.scala` for test data factories.
 
 ## Dependencies
 
-- **Otoroshi 17.11.0** - Base API gateway (provided dependency)
-- **Langchain4j 1.9.1** - LLM integration library
+- **Otoroshi 18.0.0-preview2** - Base API gateway (provided dependency, brings Play 3 / Pekko)
+- **Langchain4j 1.15.0** - LLM integration library
 - **Jlama 0.8.4** - Local LLM inference
-- **Jackson 2.15.3** - JSON processing
+- **Jackson 2.22.2** - JSON processing (kept in sync with otoroshi)

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,18 @@
-import Dependencies.*
+import Dependencies._
 import sbt.Package.ManifestAttributes
 
-ThisBuild / scalaVersion     := "2.12.18"
+ThisBuild / scalaVersion     := "3.8.4"
 ThisBuild / version          := "1.0.0-dev"
 ThisBuild / organization     := "com.cloud-apim"
 ThisBuild / organizationName := "Cloud-APIM"
 
 lazy val langchain4jVersion = "1.15.0" //"0.34.0"
-lazy val jacksonVersion = "2.15.3"
+// kept in sync with otoroshi/build.sbt so the copy we ship in the assembly is the very same one
+// otoroshi already has on its classpath at runtime
+lazy val jacksonVersion = "2.22.2"
+lazy val jacksonAnnotationVersion = "2.22" // jackson-annotations is versioned at the minor level only
+lazy val nettyVersion = "4.2.17.Final"
+lazy val luceneVersion = "9.11.1"
 lazy val jlamaVersion = "0.8.4"
 lazy val jackson = Seq(
   ExclusionRule("com.fasterxml.jackson.core", "jackson-databind"),
@@ -29,15 +34,42 @@ lazy val all = jackson ++ slf4j
 lazy val root = (project in file("."))
   .settings(
     name := "otoroshi-llm-extension",
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      // `-Wunused:all` minus explicits/implicits/params: most of the chat/audio/image/ocr model
+      // client APIs in models.scala are traits whose default method bodies answer "not supported"
+      // and legitimately ignore every argument, and the AdminExtension*Route handlers have to
+      // keep the 4-argument shape otoroshi calls them with. Everything that catches real dead
+      // code is on.
+      "-Wunused:imports,privates,locals,patvars",
+      // the wasm4s "bundle" jar (transitive, provided) vendors an older scala 3 stdlib where
+      // `scala.caps` is an object while scala-library 3.8.4 declares it as a package. otoroshi
+      // itself silences the very same warning.
+      "-Wconf:msg=package scala contains object and package with same name:s",
+    ),
     resolvers ++= Seq(
       "jitpack" at "https://jitpack.io",
       "spring-milestones" at "https://repo.spring.io/milestone",
-      "spring-snapshots" at "https://repo.spring.io/snapshot"  
+      "spring-snapshots" at "https://repo.spring.io/snapshot"
+    ),
+    // netty 4.2 moved classes around (netty-codec -> netty-codec-base) and renamed the quic/http3
+    // incubator packages. langchain4j, jlama and kreuzberg still ask for 4.1.x, which ships the
+    // same class names with the 4.1 signatures and shadows the 4.2 jars on the classpath.
+    // otoroshi runs on nettyVersion, so pin everything there.
+    dependencyOverrides ++= Seq(
+      "io.netty" % "netty-buffer"    % nettyVersion,
+      "io.netty" % "netty-codec"     % nettyVersion,
+      "io.netty" % "netty-common"    % nettyVersion,
+      "io.netty" % "netty-handler"   % nettyVersion,
+      "io.netty" % "netty-resolver"  % nettyVersion,
+      "io.netty" % "netty-transport" % nettyVersion,
     ),
     libraryDependencies ++= Seq(
-      "fr.maif" %% "otoroshi" % "17.17.0" % "provided" excludeAll (netty: _*),
+      "fr.maif" %% "otoroshi" % "18.0.0-preview2" % "provided" excludeAll (netty *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationVersion,
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
@@ -45,38 +77,45 @@ lazy val root = (project in file("."))
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion,
-      "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % jacksonVersion,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "dev.langchain4j" % "langchain4j" % "1.15.0" excludeAll(all: _*),
-      "dev.langchain4j" % "langchain4j-mcp" % "1.15.0-beta25" excludeAll(all: _*),
+      "dev.langchain4j" % "langchain4j" % "1.15.0" excludeAll(all *),
+      "dev.langchain4j" % "langchain4j-mcp" % "1.15.0-beta25" excludeAll(all *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       // for rapid dev purposes, the following 2 are marked as provided. needs to be not "provided" for release ////////
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      // "dev.langchain4j" % "langchain4j-embeddings" % langchain4jVersion % "provided" excludeAll(all: _*),
-      // "dev.langchain4j" % "langchain4j-embeddings-all-minilm-l6-v2" % langchain4jVersion % "provided" excludeAll(all: _*),
-      "dev.langchain4j" % "langchain4j-embeddings" % "1.15.0-beta25" excludeAll(all: _*),
-      "dev.langchain4j" % "langchain4j-embeddings-all-minilm-l6-v2" % "1.15.0-beta25" excludeAll(all: _*),
+      // "dev.langchain4j" % "langchain4j-embeddings" % langchain4jVersion % "provided" excludeAll(all *),
+      // "dev.langchain4j" % "langchain4j-embeddings-all-minilm-l6-v2" % langchain4jVersion % "provided" excludeAll(all *),
+      "dev.langchain4j" % "langchain4j-embeddings" % "1.15.0-beta25" excludeAll(all *),
+      "dev.langchain4j" % "langchain4j-embeddings-all-minilm-l6-v2" % "1.15.0-beta25" excludeAll(all *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "com.github.tjake" % "jlama-core" % jlamaVersion excludeAll(all: _*),
-      "com.github.tjake" % "jlama-native" % jlamaVersion excludeAll(all: _*),
-      //"com.github.tjake" % "jlama-native" % jlamaVersion classifier "linux-x86_64" classifier "osx-x86_64" classifier "osx-aarch_64" excludeAll(all: _*),
-      "com.github.tjake" % "jlama-native" % jlamaVersion classifier "linux-x86_64" classifier "osx-aarch_64" excludeAll(all: _*),
+      "com.github.tjake" % "jlama-core" % jlamaVersion excludeAll(all *),
+      "com.github.tjake" % "jlama-native" % jlamaVersion excludeAll(all *),
+      //"com.github.tjake" % "jlama-native" % jlamaVersion classifier "linux-x86_64" classifier "osx-x86_64" classifier "osx-aarch_64" excludeAll(all *),
+      "com.github.tjake" % "jlama-native" % jlamaVersion classifier "linux-x86_64" classifier "osx-aarch_64" excludeAll(all *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "dev.kreuzberg" % "kreuzberg" % "4.6.3" excludeAll(jackson: _*),
+      "dev.kreuzberg" % "kreuzberg" % "4.6.3" excludeAll(jackson *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "org.apache.lucene" % "lucene-core" % "9.11.1" excludeAll(all: _*),
-      "org.apache.lucene" % "lucene-analysis-common" % "9.11.1" excludeAll(all: _*),
-      "org.apache.lucene" % "lucene-queryparser" % "9.11.1" excludeAll(all: _*),
+      "org.apache.lucene" % "lucene-core" % luceneVersion excludeAll(all *),
+      "org.apache.lucene" % "lucene-analysis-common" % luceneVersion excludeAll(all *),
+      "org.apache.lucene" % "lucene-queryparser" % luceneVersion excludeAll(all *),
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      "io.netty" % "netty-transport-native-kqueue" % "4.1.107.Final" % "provided" excludeAll(jackson: _*),
-      "io.netty" % "netty-transport-native-epoll" % "4.1.107.Final" % "provided" excludeAll(jackson: _*),
+      "io.netty" % "netty-transport-native-kqueue" % nettyVersion % "provided" excludeAll(jackson *),
+      "io.netty" % "netty-transport-native-epoll" % nettyVersion % "provided" excludeAll(jackson *),
+      //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+      // otoroshi ships java-jq as an unmanaged jar in its lib/ directory, so it is absent from the
+      // published pom: the test suites that boot a real otoroshi need it on the test classpath
+      "com.arakelian" % "java-jq" % "1.3.0" % Test excludeAll(all *),
       munit % Test
     ),
     fork := true,
     Test / parallelExecution := false,
     Test / javaOptions ++= Seq("--add-modules=jdk.incubator.vector", "--enable-preview"),
     assembly / test  := {},
-    assembly / assemblyJarName := "otoroshi-llm-extension-assembly_2.12-dev.jar",
+    assembly / assemblyJarName := "otoroshi-llm-extension-assembly_3-dev.jar",
+    // otoroshi already provides the exact same scala3-library at runtime, no need to ship a
+    // second copy of the whole stdlib in the plugin jar
+    assembly / assemblyPackageScala / assembleArtifact := false,
     assembly / packageOptions += ManifestAttributes("Multi-Release" -> "true"),
     assembly / assemblyMergeStrategy := {
       case PathList("scala", xs @ _*) => MergeStrategy.first

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val munit = "org.scalameta" %% "munit" % "0.7.29"
+  lazy val munit = "org.scalameta" %% "munit" % "1.0.4"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.12.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")

--- a/scripts/run-offline-tests.sh
+++ b/scripts/run-offline-tests.sh
@@ -1,9 +1,16 @@
-sbt "testOnly com.cloud.apim.otoroshi.extensions.aigateway.suites.ResponsesSuite \
-                ...OpenAiResponsesConverterSuite \
-                ...CacheSuite ...AuditingSuite ...ResilienceSuite ...LoadBalancerSuite \
-                ...QuickJsGuardrailSuite ...ProviderContextSuite \
-                ...FileContentPartsProxiesSuite ...FileContentPartsSuite \
-                ...CostsTestSuite ...ProviderModelsOverrideSuite ...SearchEngineModelSuite"
+#!/bin/sh
+# Runs only the suites that do not need a real LLM provider (no API keys, no network calls
+# to openai/anthropic/...). Everything else in src/test needs credentials.
+#
+# NOTE: `testOnly` only understands `*` as a wildcard, so suites are matched with `*Name`.
 
-sbt "testOnly ...A2ASuite ...McpRegistrySuite ...McpVirtualServerMergeSuite \
-                ...McpZeroTrustSuite ...OpenApiMcpClientSuite ...RampartEngineSuite"
+set -e
+
+sbt "testOnly *ResponsesSuite *OpenAiResponsesConverterSuite \
+              *CacheSuite *suites.AuditingSuite *ResilienceSuite *LoadBalancerSuite \
+              *QuickJsGuardrailSuite *ProviderContextSuite \
+              *FileContentPartsProxiesSuite *FileContentPartsSuite \
+              *CostsTestSuite *ProviderModelsOverrideSuite *SearchEngineModelSuite"
+
+sbt "testOnly *A2ASuite *McpRegistrySuite *McpVirtualServerMergeSuite \
+              *McpZeroTrustSuite *OpenApiMcpClientSuite *RampartEngineSuite"

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/a2a.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/a2a.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.a2a
 
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneOffset}

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/client.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/client.scala
@@ -2,13 +2,14 @@ package com.cloud.apim.otoroshi.extensions.aigateway.a2a
 
 import otoroshi.env.Env
 import otoroshi.next.models.NgTlsConfig
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import play.api.libs.ws.WSBodyWritables.given
 
 // HTTP client used by A2AConnector to talk to a remote A2A agent over the JSON-RPC binding.
 // - fetches and caches the Agent Card (agent-card.json, fallback agent.json), detecting the protocol version
@@ -20,18 +21,18 @@ object A2AClient {
   private val cardCache = new TrieMap[String, (AgentCard, A2AVersion, Long)]()
   private val cardTtlMillis: Long = 5 * 60 * 1000L
 
-  private def wsCall(url: String, method: String, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, body: Option[JsValue])(implicit env: Env, ec: ExecutionContext): Future[(Int, String)] = {
+  private def wsCall(url: String, method: String, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, body: Option[JsValue])(using env: Env, ec: ExecutionContext): Future[(Int, String)] = {
     env.MtlsWs
       .url(url, tls.legacy)
       .withMethod(method)
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .applyOnWithOpt(body) { case (b, js) => b.withBody(js.stringify) }
       .execute()
       .map(r => (r.status, r.body))
   }
 
-  def fetchAgentCard(cacheId: String, baseUrl: String, cardPath: String, fallbackPath: String, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, forceRefresh: Boolean = false)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, (AgentCard, A2AVersion)]] = {
+  def fetchAgentCard(cacheId: String, baseUrl: String, cardPath: String, fallbackPath: String, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, forceRefresh: Boolean = false)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, (AgentCard, A2AVersion)]] = {
     val now = System.currentTimeMillis()
     cardCache.get(cacheId) match {
       case Some((card, version, ts)) if !forceRefresh && (now - ts) < cardTtlMillis => Right((card, version)).vfuture
@@ -68,7 +69,7 @@ object A2AClient {
       .getOrElse(fallback)
   }
 
-  def sendMessage(endpointUrl: String, version: A2AVersion, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, message: A2AMessage, tenant: Option[String] = None)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
+  def sendMessage(endpointUrl: String, version: A2AVersion, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, message: A2AMessage, tenant: Option[String] = None)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
     val method = if (version.isLegacy) "message/send" else "SendMessage"
     val msgJson = if (version.isLegacy) legacyMessageJson(message) else message.json
     val params = Json.obj("message" -> msgJson).applyOnWithOpt(tenant) { case (o, t) => o ++ Json.obj("tenant" -> t) }
@@ -90,7 +91,7 @@ object A2AClient {
 
   // streaming variant (connector streaming, Phase 4): POST with SSE accept, read the body, accumulate the text from
   // artifactUpdate/message/task events. Result is the same String the tool layer expects.
-  def sendStreamingMessage(endpointUrl: String, version: A2AVersion, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, message: A2AMessage, tenant: Option[String] = None)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
+  def sendStreamingMessage(endpointUrl: String, version: A2AVersion, headers: Seq[(String, String)], tls: NgTlsConfig, timeout: FiniteDuration, message: A2AMessage, tenant: Option[String] = None)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
     val method = if (version.isLegacy) "message/stream" else "SendStreamingMessage"
     val msgJson = if (version.isLegacy) legacyMessageJson(message) else message.json
     val params = Json.obj("message" -> msgJson).applyOnWithOpt(tenant) { case (o, t) => o ++ Json.obj("tenant" -> t) }
@@ -119,7 +120,7 @@ object A2AClient {
 
   // OAuth2 client credentials token fetch + cache (Phase 4)
   private val tokenCache = new TrieMap[String, (String, Long)]()
-  def fetchOAuthToken(tokenUrl: String, clientId: String, clientSecret: String, scope: Option[String], tls: NgTlsConfig, timeout: FiniteDuration)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
+  def fetchOAuthToken(tokenUrl: String, clientId: String, clientSecret: String, scope: Option[String], tls: NgTlsConfig, timeout: FiniteDuration)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
     val cacheKey = s"$tokenUrl|$clientId|${scope.getOrElse("")}"
     val now = System.currentTimeMillis()
     tokenCache.get(cacheKey) match {
@@ -135,7 +136,7 @@ object A2AClient {
               val expiresIn = Try(Json.parse(r.body)).toOption.flatMap(js => (js \ "expires_in").asOpt[Long]).getOrElse(3600L)
               tokenCache.put(cacheKey, (tok, now + expiresIn * 1000))
               Right(tok)
-            case None => Left(Json.obj("error" -> "oauth token fetch failed", "status" -> r.status, "body" -> r.body))
+            case None => Left(Json.obj("error" -> "oauth token fetch failed", "status" -> r.status, "body" -> (r.body: String)))
           }
         }.recover { case e: Throwable => Left(Json.obj("error" -> s"oauth token fetch failed: ${e.getMessage}")) }
     }
@@ -165,12 +166,12 @@ object A2AClient {
   }
 
   // fire-and-forget push notification webhook (Phase 4). Payload is a StreamResponse object ({ "task": … }).
-  def push(config: A2APushConfig, payload: JsValue, timeout: FiniteDuration = 10.seconds)(implicit env: Env, ec: ExecutionContext): Future[Unit] = {
+  def push(config: A2APushConfig, payload: JsValue, timeout: FiniteDuration = 10.seconds)(using env: Env, ec: ExecutionContext): Future[Unit] = {
     val authHeader = config.authentication.flatMap(_.header).toSeq
     val tokenHeader = config.token.map(t => "X-A2A-Notification-Token" -> t).toSeq
     val hdrs = Seq("Content-Type" -> A2A.mediaType) ++ authHeader ++ tokenHeader
     env.MtlsWs.url(config.url, NgTlsConfig().legacy).withMethod("POST")
-      .withHttpHeaders(hdrs: _*).withRequestTimeout(timeout).withBody(Json.stringify(payload)).execute()
+      .withHttpHeaders(hdrs*).withRequestTimeout(timeout).withBody(Json.stringify(payload)).execute()
       .map(_ => ()).recover { case _ => () }
   }
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/tasks.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/a2a/tasks.scala
@@ -2,9 +2,9 @@ package com.cloud.apim.otoroshi.extensions.aigateway.a2a
 
 import otoroshi.env.Env
 import otoroshi.storage.RedisLike
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.Base64
 import scala.concurrent.{ExecutionContext, Future}
@@ -23,7 +23,7 @@ case class A2ATaskPage(tasks: Seq[A2ATask], nextPageToken: String, pageSize: Int
 // by providing an alternative RedisLike.
 class A2ATaskStore(env: Env, redisOpt: Option[RedisLike] = None) {
 
-  private implicit val ec: ExecutionContext = env.otoroshiExecutionContext
+  private given ec: ExecutionContext = env.otoroshiExecutionContext
 
   private def redis: RedisLike = redisOpt.getOrElse(env.datastores.redis)
 
@@ -85,12 +85,12 @@ class A2ATaskStore(env: Env, redisOpt: Option[RedisLike] = None) {
       val ids = members.map(_.utf8String)
       Future.sequence(ids.map(id => get(id).map(id -> _))).flatMap { pairs =>
         val missing = pairs.collect { case (id, None) => id }
-        val healed = if (missing.nonEmpty) redis.srem(sourceKey, missing: _*).map(_ => ()) else Future.successful(())
+        val healed = if (missing.nonEmpty) redis.srem(sourceKey, missing*).map(_ => ()) else Future.successful(())
         healed.map { _ =>
           val all = pairs.collect { case (_, Some(t)) => t }
             .filter(t => status.forall(s => t.status.state == s))
             .filter(t => statusTimestampAfter.forall(after => t.status.timestamp.exists(_ >= after)))
-            .sortBy(_.status.timestamp.getOrElse(""))(Ordering[String].reverse)
+            .sortBy(_.status.timestamp.getOrElse(""))(using Ordering[String].reverse)
           val total = all.size
           val page = all.slice(offset, offset + size).map(t => if (includeArtifacts) t else t.copy(artifacts = Seq.empty))
           val next = if (offset + size < total) encodeOffset(offset + size) else ""

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/agents/agents.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/agents/agents.scala
@@ -1,19 +1,20 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.agents
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.Guardrails
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.next.workflow.{Node, NodeLike, NoopNode, WorkflowAdminExtension, WorkflowError, WorkflowOperator, WorkflowRun}
+import otoroshi.next.workflow.{Node, NodeLike, NoopNode, WorkflowError, WorkflowOperator, WorkflowRun}
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedKey
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import org.apache.pekko.stream.Materializer
 
 object InlineFunctions {
   val InlineFunctionsKey = TypedKey[Map[String, InlineFunction]]("cloud-apim.ai-gateway.InlineFunctions")
@@ -209,13 +210,13 @@ case class AgentConfig(
   guardrails: Guardrails = Guardrails(Seq.empty),
   builtInTools: AgentBuiltInTools = AgentBuiltInTools.empty,
 ) {
-  def runStr(input: String, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(implicit env: Env):  Future[Either[JsValue, String]] = {
-    run(AgentInput.from(input), rcfg, attrs, wfr).map(_.map(_.wholeTextContent))(env.otoroshiExecutionContext)
+  def runStr(input: String, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(using env: Env):  Future[Either[JsValue, String]] = {
+    run(AgentInput.from(input), rcfg, attrs, wfr).map(_.map(_.wholeTextContent))(using env.otoroshiExecutionContext)
   }
-  def run(input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(implicit env: Env):  Future[Either[JsValue, AgentOutput]] = {
+  def run(input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(using env: Env):  Future[Either[JsValue, AgentOutput]] = {
     new AgentRunner(env).run(this, input, rcfg, attrs, wfr)
   }
-  def stream(input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(implicit env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def stream(input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun])(using env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     new AgentRunner(env).stream(this, input, rcfg, attrs, wfr)
   }
   def toHandoff(): Handoff = {
@@ -286,7 +287,7 @@ object AgentConfig {
                   } else {
                     wfr.memory.set("tool_input", args.json)
                   }
-                  node.internalRun(wfr, Seq.empty, Seq.empty)(env, ec).map {
+                  node.internalRun(wfr, Seq.empty, Seq.empty)(using env, ec).map {
                     case Left(err) =>
                       wfr.attrs.get(otoroshi.next.workflow.WorkflowAdminExtension.liveUpdatesSourceKey).foreach { source =>
                         source.tryEmitNext(Json.obj("kind" -> "progress", "data" -> Json.obj(
@@ -310,7 +311,7 @@ object AgentConfig {
                       }
                       //println(s"responssssss: ${v.stringify}")
                       v.stringify
-                  }(ec)
+                  }(using ec)
                 }
               }
             },
@@ -360,9 +361,9 @@ object AgentInput {
 
 class AgentRunner(env: Env) {
 
-  implicit val ev = env
-  implicit val ec = env.otoroshiExecutionContext
-  implicit val mat = env.otoroshiMaterializer
+  given ev: Env = env
+  given ec: ExecutionContext = env.otoroshiExecutionContext
+  given mat: Materializer = env.otoroshiMaterializer
 
   lazy val ext = env.adminExtensions.extension[AiExtension].get
 
@@ -374,7 +375,7 @@ class AgentRunner(env: Env) {
   // + mcp_connectors + search_engines + memory + guardrails) but calls tryStream instead of call. Streaming supports
   // wasm/mcp tools (streamWithToolSupport in providers); handoffs and built-in tools need the multi-turn run loop and
   // are therefore not streamable here (caller should fall back to run()).
-  def stream(agent: AgentConfig, input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun]): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def stream(agent: AgentConfig, input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun]): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (agent.handoffs.exists(_.enabled) || agent.builtInTools.hasAnyEnabled) {
       Json.obj("error" -> "streaming not supported for agents with handoffs or built-in tools").leftf
     } else {
@@ -428,7 +429,7 @@ class AgentRunner(env: Env) {
     }
   }
 
-  private def internalRun(agent: AgentConfig, input: AgentInput, rcfg: AgentRunConfig = AgentRunConfig(), ctx: AgentContext = AgentContext(), attrs: TypedMap = TypedMap.empty, wfr: Option[WorkflowRun]): Future[Either[JsValue, AgentOutput]] = {
+  private def internalRun(agent: AgentConfig, input: AgentInput, rcfg: AgentRunConfig, ctx: AgentContext, attrs: TypedMap, wfr: Option[WorkflowRun]): Future[Either[JsValue, AgentOutput]] = {
     if (ctx.iteration > rcfg.maxTurns) {
       Json.obj("error" -> "Max turns reached").leftf
     } else {
@@ -528,7 +529,7 @@ class AgentRunner(env: Env) {
                             }.find(tuple => possibleNames.contains(tuple._1))
                             handoff_call match {
                               case None => Json.obj("error" -> "no handoff found").leftf
-                              case Some((name, handoff_call)) => {
+                              case Some((name, _)) => {
                                 val handoff = agent.handoffs.find(_.functionName == name).get
                                 handoff.on_handoff.foreach(_.apply(input))
                                 internalRun(handoff.agent, input, rcfg.copy(
@@ -672,7 +673,7 @@ class RouterNode(val json: JsObject) extends Node {
                     wfr: WorkflowRun,
                     prefix: Seq[Int],
                     from: Seq[Int]
-                  )(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+                  )(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     if (from.nonEmpty) {
       WorkflowError(
         s"Router Node (${prefix.mkString(".")}) does not support resume: ${from.mkString(".")}",
@@ -751,7 +752,7 @@ class RouterNode(val json: JsObject) extends Node {
                             }.find(tuple => possibleNames.contains(tuple._1))
                             handoff_call match {
                               case None => WorkflowError("no handoff found").leftf
-                              case Some((name, handoff_call, idx)) => {
+                              case Some((name, _, idx)) => {
                                 val handoff = paths.find(_.id == name).get
                                 handoff.internalRun(wfr, prefix :+ idx, from).recover { case t: Throwable =>
                                   WorkflowError(s"caught exception on task '${id}' at path: '${handoff.id}'", None, Some(t)).left
@@ -807,7 +808,7 @@ class AiAgentMcpToolsNode(val json: JsObject) extends Node {
     "mcp_ref" -> "xxxxx",
   ))
 
-  override def run(wfr: WorkflowRun, prefix: Seq[Int], from: Seq[Int])(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+  override def run(wfr: WorkflowRun, prefix: Seq[Int], from: Seq[Int])(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     JsNull.rightf
   }
 
@@ -1008,7 +1009,7 @@ class AiAgentNode(val json: JsObject) extends Node {
                     wfr: WorkflowRun,
                     prefix: Seq[Int],
                     from: Seq[Int]
-                  )(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+                  )(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     if (from.nonEmpty) {
       WorkflowError(
         s"AI Agent Node (${prefix.mkString(".")}) does not support resume: ${from.mkString(".")}",
@@ -1023,7 +1024,7 @@ class AiAgentNode(val json: JsObject) extends Node {
         .map(v => WorkflowOperator.processOperators(v, wfr, env))
         .map {
           case JsString(str) => AgentInput.from(str)
-          case JsArray(seq) => AgentInput(seq.map(v => ChatMessage.inputJson(v.asObject)))
+          case JsArray(seq) => AgentInput(seq.toSeq.map(v => ChatMessage.inputJson(v.asObject)))
           case obj @ JsObject(_) => AgentInput(Seq(ChatMessage.inputJson(obj)))
           case _ => AgentInput.empty
         }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/agents/builtintools.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/agents/builtintools.scala
@@ -6,17 +6,17 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import com.cloud.apim.otoroshi.extensions.aigateway.KreuzbergHelper
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.{LettuceRedisClientManager, PgPoolManager}
-import otoroshi.el.GlobalExpressionLanguage
 import otoroshi.env.Env
 import otoroshi.next.workflow.WorkflowRun
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
+import play.api.libs.ws.WSBodyWritables.given
 
 object BuiltInToolsFactory {
 
@@ -33,7 +33,7 @@ object BuiltInToolsFactory {
     promise.future
   }
 
-  private def ensurePgKvTable(pool: io.vertx.pgclient.PgPool)(implicit ec: ExecutionContext): Future[Unit] = {
+  private def ensurePgKvTable(pool: io.vertx.sqlclient.Pool)(using ec: ExecutionContext): Future[Unit] = {
     val key = pool.toString
     if (verifiedPgKvTables.contains(key)) {
       Future.successful(())
@@ -302,7 +302,7 @@ object BuiltInToolsFactory {
           required = Seq("command")
         ),
         call = (args, _, _, innerEc) => {
-          implicit val ec: ExecutionContext = innerEc
+          given ec: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val command = json.select("command").asOptString.getOrElse("")
           val cwd = json.select("cwd").asOptString.getOrElse(allowedPaths.head)
@@ -316,7 +316,7 @@ object BuiltInToolsFactory {
                 pb.redirectErrorStream(true)
                 val process = pb.start()
                 val outputFuture = Future {
-                  scala.io.Source.fromInputStream(process.getInputStream)("UTF-8").mkString
+                  scala.io.Source.fromInputStream(process.getInputStream)(using "UTF-8").mkString
                 }
                 val completed = process.waitFor(timeoutMs.toLong, TimeUnit.MILLISECONDS)
                 if (!completed) {
@@ -433,7 +433,7 @@ object BuiltInToolsFactory {
           strict = false,
           parameters = Json.obj()
         ),
-        call = (args, _, _, _) => {
+        call = (_, _, _, _) => {
           val tasks = scratchpadRef.get().tasks.map(t => Json.obj("id" -> t.id, "title" -> t.title, "description" -> t.description, "status" -> t.status))
           Future.successful(Json.obj("tasks" -> tasks).stringify)
         }
@@ -488,7 +488,7 @@ object BuiltInToolsFactory {
           strict = false,
           parameters = Json.obj()
         ),
-        call = (args, _, _, _) => {
+        call = (_, _, _, _) => {
           val plan = scratchpadRef.get().plan
           plan match {
             case None => Future.successful(Json.obj("plan" -> JsNull).stringify)
@@ -556,7 +556,7 @@ object BuiltInToolsFactory {
           strict = false,
           parameters = Json.obj()
         ),
-        call = (args, _, _, _) => {
+        call = (_, _, _, _) => {
           val notes = scratchpadRef.get().notes
           Future.successful(Json.obj("entries" -> JsObject(notes.toSeq)).stringify)
         }
@@ -580,7 +580,7 @@ object BuiltInToolsFactory {
           required = Seq("objective")
         ),
         call = (args, _, innerEnv, innerEc) => {
-          implicit val implEc: ExecutionContext = innerEc
+          given implEc: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val objective = json.select("objective").asOptString.getOrElse("")
           val agentName = json.select("agent_name").asOptString
@@ -630,7 +630,7 @@ object BuiltInToolsFactory {
           required = Seq("url")
         ),
         call = (args, _, innerEnv, innerEc) => {
-          implicit val implEc: ExecutionContext = innerEc
+          given implEc: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val url = json.select("url").asOptString.getOrElse("")
           val method = json.select("method").asOptString.getOrElse("GET").toUpperCase
@@ -640,11 +640,11 @@ object BuiltInToolsFactory {
           val convertToMarkdown = json.select("convert_to_markdown").asOpt[Boolean].getOrElse(false)
 
           try {
-            val headerSeq = headers.fields.map { case (k, v) => (k, v.asOpt[String].getOrElse(v.toString())) }
+            val headerSeq = headers.fields.toSeq.map { case (k, v) => (k, v.asOpt[String].getOrElse(v.toString())) }
             var req = innerEnv.Ws
               .url(url)
               .withRequestTimeout(scala.concurrent.duration.Duration(timeout.toLong, "millis"))
-              .withHttpHeaders(headerSeq: _*)
+              .withHttpHeaders(headerSeq*)
               .withFollowRedirects(true)
             req = bodyOpt match {
               case Some(JsString(s)) => req.withBody(s)
@@ -656,7 +656,7 @@ object BuiltInToolsFactory {
               val respHeaders = resp.headers.map { case (k, v) => k -> JsString(v.mkString(", ")) }
               if (convertToMarkdown) {
                 val contentType = resp.header("Content-Type").getOrElse("application/octet-stream").split(";").head.trim
-                KreuzbergHelper.extractFromBytes(resp.bodyAsBytes.toArray, contentType)(env, implEc).map { markdown =>
+                KreuzbergHelper.extractFromBytes(resp.bodyAsBytes.toArray, contentType)(using env, implEc).map { markdown =>
                   Json.obj(
                     "status" -> resp.status,
                     "headers" -> JsObject(respHeaders.toSeq),
@@ -704,8 +704,8 @@ object BuiltInToolsFactory {
           )
         ),
         call = (args, _, innerEnv, innerEc) => {
-          implicit val implEc: ExecutionContext = innerEc
-          implicit val implEnv: Env = innerEnv
+          given implEc: ExecutionContext = innerEc
+          given implEnv: Env = innerEnv
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val urlOpt = json.select("url").asOptString
           val contentOpt = json.select("content").asOptString
@@ -751,7 +751,7 @@ object BuiltInToolsFactory {
           required = Seq("objective", "instructions")
         ),
         call = (args, _, innerEnv, innerEc) => {
-          implicit val implEc: ExecutionContext = innerEc
+          given implEc: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val objective = json.select("objective").asOptString.getOrElse("")
           val instructions = json.select("instructions").asOptString.getOrElse("")
@@ -795,7 +795,7 @@ object BuiltInToolsFactory {
     if (config.isEnabled("persistent_kv_set")) {
       val kvUri = config.persistentKvUri.get
       val rawNamespace = config.persistentKvNamespace.getOrElse(s"agent-kv:${agent.name}:default")
-      val namespace = if (rawNamespace.contains("${")) rawNamespace.evaluateEl(attrs)(env) else rawNamespace
+      val namespace = if (rawNamespace.contains("${")) rawNamespace.evaluateEl(attrs)(using env) else rawNamespace
       val isRedis = kvUri.startsWith("redis://") || kvUri.startsWith("rediss://")
 
       tools += InlineFunction(
@@ -810,7 +810,7 @@ object BuiltInToolsFactory {
           required = Seq("key", "value")
         ),
         call = (args, _, _, innerEc) => {
-          implicit val ec: ExecutionContext = innerEc
+          given ec: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val key = json.select("key").asOptString.getOrElse("_")
           val value = json.select("value").asOpt[JsValue].map(Json.stringify).getOrElse(json.select("value").asOptString.getOrElse(""))
@@ -842,7 +842,7 @@ object BuiltInToolsFactory {
           required = Seq("key")
         ),
         call = (args, _, _, innerEc) => {
-          implicit val ec: ExecutionContext = innerEc
+          given ec: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val key = json.select("key").asOptString.getOrElse("_")
           if (isRedis) {
@@ -879,7 +879,7 @@ object BuiltInToolsFactory {
           required = Seq("key")
         ),
         call = (args, _, _, innerEc) => {
-          implicit val ec: ExecutionContext = innerEc
+          given ec: ExecutionContext = innerEc
           val json = Try(Json.parse(args)).getOrElse(Json.obj())
           val key = json.select("key").asOptString.getOrElse("_")
           if (isRedis) {
@@ -905,8 +905,8 @@ object BuiltInToolsFactory {
           strict = false,
           parameters = Json.obj()
         ),
-        call = (args, _, _, innerEc) => {
-          implicit val ec: ExecutionContext = innerEc
+        call = (_, _, _, innerEc) => {
+          given ec: ExecutionContext = innerEc
           if (isRedis) {
             val conn = LettuceRedisClientManager.getConnection(kvUri)
             toScalaFuture(conn.async().hgetall(namespace))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchConfig.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchConfig.scala
@@ -1,6 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.docsearch
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 final case class CorpusSource(id: String, url: String, baseUrl: String)
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchCorpus.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchCorpus.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.docsearch
 
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 
 private object DocSearchCorpusLog {
@@ -26,7 +26,7 @@ object DocSearchCorpus {
     source: CorpusSource,
     previousEtag: Option[String],
     previousLastModified: Option[String]
-  )(implicit ec: ExecutionContext, env: Env): Future[CorpusFetchResult] = {
+  )(using ec: ExecutionContext, env: Env): Future[CorpusFetchResult] = {
     val logger = DocSearchCorpusLog.logger
     val baseHeaders: Seq[(String, String)] = Seq(
       "Accept" -> "application/json",
@@ -42,7 +42,7 @@ object DocSearchCorpus {
       logger.debug(s"doc-search fetch start: corpus=${source.id} url=${source.url}$conditionalNote")
     }
     env.Ws.url(source.url)
-      .withHttpHeaders((baseHeaders ++ conditional): _*)
+      .withHttpHeaders((baseHeaders ++ conditional)*)
       .withFollowRedirects(true)
       .withRequestTimeout(fetchTimeout)
       .get()

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchIndex.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchIndex.scala
@@ -33,14 +33,14 @@ final class DocSearchIndex(val config: DocSearchConfig) {
 
   def invalidate(): Unit = state.set(None)
 
-  def search(query: String, corpus: Option[String])(implicit ec: ExecutionContext, env: Env): Future[Either[String, Seq[DocSearchResult]]] = {
+  def search(query: String, corpus: Option[String])(using ec: ExecutionContext, env: Env): Future[Either[String, Seq[DocSearchResult]]] = {
     ensureFresh().map { _ =>
       state.get() match {
         case None =>
           if (building.get()) Left("doc search index is still being built — retry in a few seconds")
           else Left("doc search index is not available")
         case Some(s) =>
-          val filterCorpus: ((String, _)) => Boolean = {
+          val filterCorpus: ((String, ?)) => Boolean = {
             case (id, _) =>
               corpus match {
                 case None => true
@@ -64,7 +64,7 @@ final class DocSearchIndex(val config: DocSearchConfig) {
     }
   }
 
-  private def ensureFresh()(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  private def ensureFresh()(using ec: ExecutionContext, env: Env): Future[Unit] = {
     val now = System.currentTimeMillis()
     state.get() match {
       case Some(s) if now - s.builtAt < config.ttl.toMillis => Future.successful(())
@@ -78,7 +78,7 @@ final class DocSearchIndex(val config: DocSearchConfig) {
     }
   }
 
-  private def triggerRebuild()(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  private def triggerRebuild()(using ec: ExecutionContext, env: Env): Future[Unit] = {
     if (!building.compareAndSet(false, true)) {
       logger.debug("doc-search: rebuild already in progress, skipping")
       return Future.successful(())

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchTool.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/DocSearchTool.scala
@@ -1,9 +1,9 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.docsearch
 
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools.{AssistantTool, ToolCallContext, ToolDefinition}
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -43,7 +43,7 @@ class DocSearchTool extends AssistantTool {
     )
   )
 
-  override def call(arguments: JsValue, ctx: ToolCallContext)(implicit ec: ExecutionContext): Future[String] = {
+  override def call(arguments: JsValue, ctx: ToolCallContext)(using ec: ExecutionContext): Future[String] = {
     val query = arguments.select("query").asOpt[String].map(_.trim).getOrElse("")
     if (query.isEmpty) {
       logger.warn("doc_search called with empty query")
@@ -53,7 +53,7 @@ class DocSearchTool extends AssistantTool {
     val index = DocSearchIndex.get()
     if (logger.isDebugEnabled) logger.debug(s"doc_search call: query=${quote(query)} corpus=${corpus.getOrElse("<all>")} index.ready=${index.isReady} index.building=${index.isBuilding}")
     val startedAt = System.currentTimeMillis()
-    implicit val env: otoroshi.env.Env = ctx.env
+    given env: otoroshi.env.Env = ctx.env
     index.search(query, corpus).map {
       case Left(message) =>
         val took = System.currentTimeMillis() - startedAt

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/LexicalIndex.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/LexicalIndex.scala
@@ -9,7 +9,7 @@ import org.apache.lucene.search.IndexSearcher
 import org.apache.lucene.search.similarities.BM25Similarity
 import org.apache.lucene.store.ByteBuffersDirectory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 
 final class LexicalIndex private (
   directory: ByteBuffersDirectory,

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/SemanticIndex.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/docsearch/SemanticIndex.scala
@@ -6,7 +6,7 @@ import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2Embedding
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest
 import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 
 final class SemanticIndex private (
   store: InMemoryEmbeddingStore[TextSegment],

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/AdminClient.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/AdminClient.scala
@@ -2,15 +2,14 @@ package com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic
 
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools.ToolCallContext
 import otoroshi.env.Env
-import otoroshi.models.{ApiKey, BackOfficeUser}
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import otoroshi.models.ApiKey
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import java.net.URI
-import java.util.Base64
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 case class AdminCredentials(baseUrl: String, apikey: ApiKey) {
   def bearer: String = apikey.toBearer()
@@ -82,7 +81,7 @@ object AdminClient {
     if (parts.isEmpty) "" else parts.mkString("?", "&", "")
   }
 
-  def request(creds: AdminCredentials, method: String, path: String, opts: CallOptions = CallOptions())(implicit ec: ExecutionContext, env: Env): Future[Either[String, AdminResponse]] = {
+  def request(creds: AdminCredentials, method: String, path: String, opts: CallOptions = CallOptions())(using ec: ExecutionContext, env: Env): Future[Either[String, AdminResponse]] = {
     val resolvedPath = try interpolatePath(path, opts.pathParams) catch { case e: IllegalArgumentException => return Left(e.getMessage).vfuture }
     if (resolvedPath.matches("(?i)^[a-z][a-z0-9+.-]*:.*")) return Left(s"Refusing absolute URL in path: $resolvedPath").vfuture
     if (resolvedPath.startsWith("//")) return Left(s"Refusing protocol-relative path: $resolvedPath").vfuture
@@ -102,7 +101,7 @@ object AdminClient {
     val finalHeaders = if (hasBody) baseHeaders + ("Content-Type" -> "application/json") else baseHeaders
 
     var builder = env.Ws.url(finalUrl)
-      .withHttpHeaders(finalHeaders.toSeq: _*)
+      .withHttpHeaders(finalHeaders.toSeq*)
       .withMethod(httpMethod)
       .withRequestTimeout(defaultRequestTimeout)
       .withFollowRedirects(false)
@@ -123,7 +122,7 @@ object AdminClient {
     }.recover { case t: Throwable => Left(s"http call failed: ${t.getMessage}") }
   }
 
-  def call(creds: AdminCredentials, catalog: Catalog.Document, operationId: String, opts: CallOptions = CallOptions())(implicit ec: ExecutionContext, env: Env): Future[Either[String, AdminResponse]] = {
+  def call(creds: AdminCredentials, catalog: Catalog.Document, operationId: String, opts: CallOptions = CallOptions())(using ec: ExecutionContext, env: Env): Future[Either[String, AdminResponse]] = {
     catalog.byOperationId.get(operationId) match {
       case None => Left(s"Unknown operationId '$operationId'. Use the 'search' tool to discover operations.").vfuture
       case Some(op) => request(creds, op.method, op.path, opts)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/Catalog.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/Catalog.scala
@@ -2,10 +2,10 @@ package com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic
 
 import otoroshi.api.OpenApi
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 object Catalog {
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/DocResource.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/DocResource.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic
 
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 
 import java.net.URI
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 
 object DocResource {
@@ -54,7 +54,7 @@ object DocResource {
     case class Failed(message: String) extends FetchResult
   }
 
-  def fetch(url: String)(implicit ec: ExecutionContext, env: Env): Future[FetchResult] = {
+  def fetch(url: String)(using ec: ExecutionContext, env: Env): Future[FetchResult] = {
     val parsed = scala.util.Try(new URI(url)).toOption
     parsed match {
       case None => FetchResult.InvalidUrl(s"Invalid URL: $url").vfuture.asInstanceOf[Future[FetchResult]]

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/ExpressionLanguage.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/logic/ExpressionLanguage.scala
@@ -1,6 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.matching.Regex
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/otoassistant.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/otoassistant.scala
@@ -1,20 +1,21 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools.{AssistantTool, ToolCallContext, ToolRegistry}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.models.BackOfficeUser
-import otoroshi.next.extensions._
+import otoroshi.next.extensions.*
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
-import play.api.mvc._
+import play.api.libs.json.*
+import play.api.mvc.*
 
 import scala.concurrent.{ExecutionContext, Future}
+import org.apache.pekko.stream.Materializer
 
 object OtoroshiAssistant {
 
@@ -190,7 +191,7 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
   //private val maxToolCallIterations: Int = 20
 
   private def gc = {
-    env.datastores.globalConfigDataStore.latest()(env.otoroshiExecutionContext, env)
+    env.datastores.globalConfigDataStore.latest()(using env.otoroshiExecutionContext, env)
   }
   private def config: AssistantConfiguration = {
     AssistantConfiguration.fromJson(gc.extensions.get("cloud-apim_extensions_LlmExtension").flatMap(_.select("otoroshiassistant").asOpt[JsObject]).getOrElse(Json.obj()))
@@ -205,10 +206,10 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
 
   def isEnabled: Boolean = config.enabled && assistantProvider.isDefined
 
-  def handleAssistantCompletion(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleAssistantCompletion(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     if (isEnabled) {
       body match {
         case None => Results.BadRequest(Json.obj("error" -> "No body")).vfuture
@@ -267,8 +268,8 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
     registry: ToolRegistry,
     toolCtx: ToolCallContext,
     iteration: Int,
-  )(implicit ec: ExecutionContext): Future[Either[JsValue, ChatResponse]] = {
-    implicit val ev: Env = env
+  )(using ec: ExecutionContext): Future[Either[JsValue, ChatResponse]] = {
+    given ev: Env = env
     if (iteration >= config.maxToolCalls) {
       Left[JsValue, ChatResponse](JsString(s"Max tool-call iterations reached (${config.maxToolCalls}).")).vfuture
     } else {
@@ -294,7 +295,7 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
     }
   }
 
-  private def runToolCall(tc: JsObject, registry: ToolRegistry, toolCtx: ToolCallContext)(implicit ec: ExecutionContext): Future[InputChatMessage] = {
+  private def runToolCall(tc: JsObject, registry: ToolRegistry, toolCtx: ToolCallContext)(using ec: ExecutionContext): Future[InputChatMessage] = {
     val callId = tc.select("id").asOpt[String].getOrElse(java.util.UUID.randomUUID().toString)
     val fn = tc.select("function").asOpt[JsObject].getOrElse(Json.obj())
     val name = fn.select("name").asOpt[String].getOrElse("")
@@ -357,24 +358,24 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
     registry: ToolRegistry,
     toolCtx: ToolCallContext,
     iteration: Int,
-  )(implicit ec: ExecutionContext): Future[Either[JsValue, Source[AssistantStreamEvent, _]]] = {
-    implicit val ev: Env = env
+  )(using ec: ExecutionContext): Future[Either[JsValue, Source[AssistantStreamEvent, ?]]] = {
+    given ev: Env = env
     if (iteration >= config.maxToolCalls) {
-      Left[JsValue, Source[AssistantStreamEvent, _]](JsString(s"Max tool-call iterations reached (${config.maxToolCalls}).")).vfuture
+      Left[JsValue, Source[AssistantStreamEvent, ?]](JsString(s"Max tool-call iterations reached (${config.maxToolCalls}).")).vfuture
     } else {
       // println(s"[assistant.stream] iter=$iteration starting (messages=${messages.size})")
       client.stream(ChatPrompt(messages, None), TypedMap.empty, baseBody).map {
         case Left(err) =>
           // println(s"[assistant.stream] iter=$iteration upstream LEFT: $err")
-          Left[JsValue, Source[AssistantStreamEvent, _]](err)
+          Left[JsValue, Source[AssistantStreamEvent, ?]](err)
         case Right(source) =>
           val assistantContent = new StringBuilder()
           val buffer = new StreamingToolCallBuffer()
           @volatile var triggered = false
           val chunkCount = new java.util.concurrent.atomic.AtomicInteger(0)
 
-          val transformed: Source[AssistantStreamEvent, _] = source.flatMapConcat { chunk =>
-            val n = chunkCount.incrementAndGet()
+          val transformed: Source[AssistantStreamEvent, ?] = source.flatMapConcat { chunk =>
+            val _ = chunkCount.incrementAndGet()
             if (triggered) {
               // println(s"[assistant.stream] iter=$iteration chunk#$n DROPPED (already triggered): ${chunk.choices.headOption.map(_.json.stringify).getOrElse("?")}")
               Source.empty[AssistantStreamEvent]
@@ -382,7 +383,6 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
               val choice = chunk.choices.headOption
               val deltaToolCalls = choice.toSeq.flatMap(_.delta.tool_calls)
               val finishReason = choice.flatMap(_.finishReason)
-              val deltaContent = choice.flatMap(_.delta.content)
               // println(s"[assistant.stream] iter=$iteration chunk#$n content=${deltaContent.map(s => s"'${s.take(40)}'").getOrElse("-")} toolCallDeltas=${deltaToolCalls.size} finish=${finishReason.getOrElse("-")} bufferSize=${buffer.byIndex.size}")
 
               if (deltaToolCalls.nonEmpty) {
@@ -408,7 +408,7 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
                 }
 
                 val toolRunsF: Future[Seq[(InputChatMessage, AssistantStreamEvent.ToolCallFinished)]] =
-                  Future.sequence(toolCallObjs.map { tc =>
+                  Future.sequence(toolCallObjs.toSeq.map { tc =>
                     val startTs = System.currentTimeMillis()
                     val id = tc.select("id").asOpt[String].getOrElse("")
                     val name = tc.select("function").select("name").asOpt[String].getOrElse("")
@@ -438,7 +438,7 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
                     }
                   })
 
-                val nextStepF: Future[Source[AssistantStreamEvent, _]] = toolRunsF.flatMap { results =>
+                val nextStepF: Future[Source[AssistantStreamEvent, ?]] = toolRunsF.flatMap { results =>
                   val msgs = results.map(_._1)
                   val finishedEvents: List[AssistantStreamEvent] = results.map(_._2: AssistantStreamEvent).toList
                   val newMessages = (messages :+ assistantMsg) ++ msgs
@@ -455,22 +455,22 @@ class OtoroshiAssistant(env: Env, ext: AiExtension) {
               }
             }
           }
-          Right[JsValue, Source[AssistantStreamEvent, _]](transformed)
+          Right[JsValue, Source[AssistantStreamEvent, ?]](transformed)
       }
     }
   }
 }
 
 sealed trait AssistantStreamEvent {
-  def asSse(env: Env): akka.util.ByteString
+  def asSse(env: Env): org.apache.pekko.util.ByteString
 }
 
 object AssistantStreamEvent {
   case class Chunk(chunk: ChatResponseChunk) extends AssistantStreamEvent {
-    def asSse(env: Env): akka.util.ByteString = chunk.openaiEventSource(env)
+    def asSse(env: Env): org.apache.pekko.util.ByteString = chunk.openaiEventSource(env)
   }
   case class ToolCallStarted(id: String, name: String, arguments: String, iteration: Int) extends AssistantStreamEvent {
-    def asSse(env: Env): akka.util.ByteString = {
+    def asSse(env: Env): org.apache.pekko.util.ByteString = {
       val payload = Json.obj(
         "otoroshi_assistant_event" -> "tool_call_started",
         "id" -> id,
@@ -478,11 +478,11 @@ object AssistantStreamEvent {
         "arguments" -> arguments,
         "iteration" -> iteration,
       )
-      akka.util.ByteString(s"data: ${payload.stringify}\n\n")
+      org.apache.pekko.util.ByteString(s"data: ${payload.stringify}\n\n")
     }
   }
   case class ToolCallFinished(id: String, name: String, ok: Boolean, durationMs: Long, iteration: Int) extends AssistantStreamEvent {
-    def asSse(env: Env): akka.util.ByteString = {
+    def asSse(env: Env): org.apache.pekko.util.ByteString = {
       val payload = Json.obj(
         "otoroshi_assistant_event" -> "tool_call_finished",
         "id" -> id,
@@ -491,7 +491,7 @@ object AssistantStreamEvent {
         "duration_ms" -> durationMs,
         "iteration" -> iteration,
       )
-      akka.util.ByteString(s"data: ${payload.stringify}\n\n")
+      org.apache.pekko.util.ByteString(s"data: ${payload.stringify}\n\n")
     }
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/AssistantTool.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/AssistantTool.scala
@@ -4,7 +4,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.assistant.AssistantConfigura
 import otoroshi.env.Env
 import otoroshi.models.BackOfficeUser
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -14,7 +14,7 @@ case class ToolDefinition(name: String, description: String, parameters: JsObjec
 
 trait AssistantTool {
   def definition: ToolDefinition
-  def call(arguments: JsValue, ctx: ToolCallContext)(implicit ec: ExecutionContext): Future[String]
+  def call(arguments: JsValue, ctx: ToolCallContext)(using ec: ExecutionContext): Future[String]
 
   def openaiJson: JsObject = Json.obj(
     "type" -> "function",

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/DocTool.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/DocTool.scala
@@ -1,8 +1,8 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools
 
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic.DocResource
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -33,7 +33,7 @@ class DocTool extends AssistantTool {
     ),
   )
 
-  override def call(arguments: JsValue, ctx: ToolCallContext)(implicit ec: ExecutionContext): Future[String] = {
+  override def call(arguments: JsValue, ctx: ToolCallContext)(using ec: ExecutionContext): Future[String] = {
     val topic = arguments.select("topic").asOpt[String].map(_.trim).filter(_.nonEmpty)
     val url = arguments.select("url").asOpt[String].map(_.trim).filter(_.nonEmpty)
 
@@ -41,7 +41,7 @@ class DocTool extends AssistantTool {
 
     val resultF = if (topic.isDefined && url.isDefined) Future.successful("Error: provide either 'topic' or 'url', not both.")
     else url match {
-      case Some(u) => fetchUrl(u)(ec, ctx.env)
+      case Some(u) => fetchUrl(u)(using ec, ctx.env)
       case None => Future.successful(renderStartingPoints(topic))
     }
     resultF.map { response =>
@@ -62,7 +62,7 @@ class DocTool extends AssistantTool {
     }
   }
 
-  private def fetchUrl(url: String)(implicit ec: ExecutionContext, env: otoroshi.env.Env): Future[String] = {
+  private def fetchUrl(url: String)(using ec: ExecutionContext, env: otoroshi.env.Env): Future[String] = {
     DocResource.fetch(url).map {
       case DocResource.FetchResult.Ok(content) => AssistantTool.truncate(content)
       case DocResource.FetchResult.InvalidUrl(msg) => s"Error: $msg"

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/ExecuteTool.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/ExecuteTool.scala
@@ -1,18 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools
 
-import akka.http.scaladsl.model.Uri
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic.{AdminClient, AdminCredentials, ExpressionLanguage}
 import otoroshi.env.Env
 import otoroshi.models.ApiKey
-import otoroshi.next.proxy.{BackOfficeRequest, ProxyEngine, RelayRoutingRequest}
+import otoroshi.next.proxy.ProxyEngine
 import otoroshi.script.RequestHandler
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.{Cell, RemoteConnection, RequestAttrKey, RequestTarget}
-import play.api.mvc.{Cookies, EssentialAction, Headers, Request, Results}
+import play.api.mvc.{Cookies, Headers, Request, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -76,7 +76,7 @@ class ExecuteTool extends AssistantTool {
     ),
   )
 
-  override def call(arguments: JsValue, ctx: ToolCallContext)(implicit ec: ExecutionContext): Future[String] = {
+  override def call(arguments: JsValue, ctx: ToolCallContext)(using ec: ExecutionContext): Future[String] = {
     if (!ctx.config.allowApiUsage) {
       Future.successful("Error: Admin API usage is disabled. You have to enabled it in danger zone")
     } else {
@@ -89,7 +89,7 @@ class ExecuteTool extends AssistantTool {
         case None =>
           Future.successful("Error: admin API credentials are not configured for the assistant. The 'execute' tool is unavailable until they are wired up. Use 'search' for discovery and answer with concrete payload examples instead.")
         case Some(creds) =>
-          implicit val env = ctx.env
+          given env: Env = ctx.env
           runSequentially(creds, ctx, requests, 0, Vector.empty)
             .map(entries => JsObject(entries))
             .map(json => AssistantTool.truncate(Json.prettyPrint(json)))
@@ -107,7 +107,7 @@ class ExecuteTool extends AssistantTool {
     requests: Seq[JsObject],
     idx: Int,
     acc: Vector[(String, JsValue)],
-  )(implicit ec: ExecutionContext, env: otoroshi.env.Env): Future[Vector[(String, JsValue)]] = {
+  )(using ec: ExecutionContext, env: otoroshi.env.Env): Future[Vector[(String, JsValue)]] = {
     if (idx >= requests.size) Future.successful(acc)
     else {
       val rawReq = requests(idx)
@@ -118,7 +118,7 @@ class ExecuteTool extends AssistantTool {
     }
   }
 
-  private def runSingle(creds: AdminCredentials, ctx: ToolCallContext, rawReq: JsObject, refCtx: Map[String, JsValue])(implicit ec: ExecutionContext, env: otoroshi.env.Env): Future[JsValue] = {
+  private def runSingle(creds: AdminCredentials, ctx: ToolCallContext, rawReq: JsObject, refCtx: Map[String, JsValue])(using ec: ExecutionContext, env: otoroshi.env.Env): Future[JsValue] = {
     ExpressionLanguage.expandValue(rawReq, refCtx) match {
       case Left(err) => Future.successful(Json.obj("error" -> s"unresolved expression: $err"))
       case Right(expanded) =>
@@ -147,9 +147,9 @@ class ExecuteTool extends AssistantTool {
           val host = env.adminApiExposedHost
           val apikey = creds.apikey
           val request = new AssistantRequest(host, method, url, opts, apikey, env)
-          val engine = env.scriptManager.getAnyScript[RequestHandler](s"cp:${classOf[ProxyEngine].getName}").right.get
+          val engine = env.scriptManager.getAnyScript[RequestHandler](s"cp:${classOf[ProxyEngine].getName}").toOption.get
           engine.handle(request, _ => Results.InternalServerError("bad default routing").vfuture).flatMap { resp =>
-            resp.body.dataStream.runFold(ByteString.empty)(_ ++ _)(env.otoroshiMaterializer).map { bodyRaw =>
+            resp.body.dataStream.runFold(ByteString.empty)(_ ++ _)(using env.otoroshiMaterializer).map { bodyRaw =>
               val ctype = resp.header.headers.getIgnoreCase("content-type").getOrElse("text/plain")
               val body: JsValue = if (ctype.startsWith("application/json")) bodyRaw.utf8String.parseJson else bodyRaw.utf8String.json
               Json.obj(
@@ -165,7 +165,7 @@ class ExecuteTool extends AssistantTool {
 
 }
 
-class AssistantRequest(_host: String, m: String, _url: String, opts: AdminClient.CallOptions, apikey: ApiKey, env: Env) extends Request[Source[ByteString, _]] {
+class AssistantRequest(_host: String, m: String, _url: String, opts: AdminClient.CallOptions, apikey: ApiKey, env: Env) extends Request[Source[ByteString, ?]] {
 
 
   val bodyBs  = opts.body.map(_.stringify.byteString)
@@ -180,13 +180,13 @@ class AssistantRequest(_host: String, m: String, _url: String, opts: AdminClient
 
   override def hasBody: Boolean = opts.body.isDefined
 
-  override def body: Source[ByteString, _] = opts.body.map(json => Source.single(json.stringify.byteString)).getOrElse(Source.empty[ByteString])
+  override def body: Source[ByteString, ?] = opts.body.map(json => Source.single(json.stringify.byteString)).getOrElse(Source.empty[ByteString])
 
   override def connection: RemoteConnection = RemoteConnection("127.0.0.1", true, None)
 
   override def method: String = m.toUpperCase()
 
-  override def target: RequestTarget = RequestTarget(_url, Uri(_url).path.toString(), opts.query.mapValues(v => Seq(v)))
+  override def target: RequestTarget = RequestTarget(_url, Uri(_url).path.toString(), opts.query.view.mapValues(v => Seq(v)).toMap)
 
   override def version: String = "HTTP/1.1"
 
@@ -198,7 +198,7 @@ class AssistantRequest(_host: String, m: String, _url: String, opts: AdminClient
         "Content-Type" -> "application/json",
         "Content-Length" -> bodyBsSize.toString,
         "Authorization" -> s"Bearer ${apikey.toBearer()}"
-      ): _*
+      )*
     )
   } else {
     Headers.apply(
@@ -206,7 +206,7 @@ class AssistantRequest(_host: String, m: String, _url: String, opts: AdminClient
         "Host" -> _host,
         "Accept" -> "application/json",
         "Authorization" -> s"Bearer ${apikey.toBearer()}"
-      ): _*
+      )*
     )
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/SearchTool.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/SearchTool.scala
@@ -1,8 +1,8 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools
 
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic.Catalog
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -44,7 +44,7 @@ class SearchTool extends AssistantTool {
     ),
   )
 
-  override def call(arguments: JsValue, ctx: ToolCallContext)(implicit ec: ExecutionContext): Future[String] = {
+  override def call(arguments: JsValue, ctx: ToolCallContext)(using ec: ExecutionContext): Future[String] = {
     val query = arguments.select("query").asOpt[String].map(_.trim).getOrElse("")
     if (query.isEmpty) return Future.successful("Error: missing 'query' argument.")
     println(s"call tool 'search': ${query}")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/ToolRegistry.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/assistant/tools/ToolRegistry.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools
 
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.docsearch.DocSearchTool
-import play.api.libs.json._
+import play.api.libs.json.*
 
 class ToolRegistry {
   private val tools: Seq[AssistantTool] = Seq(

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/auditing.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/auditing.scala
@@ -1,16 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.http.scaladsl.util.FastFuture
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.util.FastFuture
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiBudget, AiBudgetConsumptions, AiBudgetUsageKind, AiBudgetsDataStore, AiProvider, AudioModel, EmbeddingModel, ImageModel, ModerationModel, OcrModel, VideoModel}
-import com.cloud.apim.otoroshi.extensions.aigateway.{AudioGenModel, AudioGenVoice, AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions, AudioTranscriptionResponse, ChatCallKind, ChatClient, ChatGeneration, ChatPrompt, ChatResponse, ChatResponseChunk, ChatResponseChunkChoice, ChatResponseChunkChoiceDelta, ChatResponseMetadata, ChatResponseMetadataRateLimit, ChatResponseMetadataUsage, EmbeddingClientInputOptions, EmbeddingModelClient, EmbeddingResponse, ImageModelClient, ImageModelClientEditionInputOptions, ImageModelClientGenerationInputOptions, ImagesGenResponse, ImagesGenResponseMetadata, ModerationModelClient, ModerationModelClientInputOptions, ModerationResponse, OcrModelClient, OcrModelClientInputOptions, OcrModelClientResponse, OutputChatMessage, VideoModelClient, VideoModelClientTextToVideoInputOptions, VideosGenResponse}
+import com.cloud.apim.otoroshi.extensions.aigateway.{AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions, AudioTranscriptionResponse, ChatCallKind, ChatClient, ChatGeneration, ChatPrompt, ChatResponse, ChatResponseChunk, ChatResponseChunkChoice, ChatResponseChunkChoiceDelta, ChatResponseMetadata, ChatResponseMetadataRateLimit, ChatResponseMetadataUsage, EmbeddingClientInputOptions, EmbeddingModelClient, EmbeddingResponse, ImageModelClient, ImageModelClientEditionInputOptions, ImageModelClientGenerationInputOptions, ImagesGenResponse, ModerationModelClient, ModerationModelClientInputOptions, ModerationResponse, OcrModelClient, OcrModelClientInputOptions, OcrModelClientResponse, OutputChatMessage, VideoModelClient, VideoModelClientTextToVideoInputOptions, VideosGenResponse}
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.events.AuditEvent
 import otoroshi.models.Entity
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.LlmTokensRateLimitingValidatorConfig
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsString, JsValue, Json}
@@ -67,14 +67,14 @@ class ChatClientWithAuditing(originalProvider: AiProvider, val chatClient: ChatC
     "provider_details" -> originalProvider.json,
   )
 
-  private def auditError(consumedUsing: String, prompt: ChatPrompt, attrs: TypedMap, error: JsValue)(implicit env: Env): Unit = {
+  private def auditError(consumedUsing: String, prompt: ChatPrompt, attrs: TypedMap, error: JsValue)(using env: Env): Unit = {
     AuditEvent.generic("LLMUsageAudit") {
       commonFields(consumedUsing, prompt, attrs) ++ Json.obj("error" -> error, "output" -> JsNull)
     }.toAnalytics()
   }
 
   // usage/costs/impacts are only known once the inner clients have run, hence the attrs lookups
-  private def auditSuccess(consumedUsing: String, prompt: ChatPrompt, attrs: TypedMap, output: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  private def auditSuccess(consumedUsing: String, prompt: ChatPrompt, attrs: TypedMap, output: JsObject)(using ec: ExecutionContext, env: Env): Future[Unit] = {
     val usageSlug: JsObject = attrs.get(otoroshi.plugins.Keys.ExtraAnalyticsDataKey).flatMap(_.select("ai").asOpt[Seq[JsObject]]).flatMap(_.lastOption).flatMap(_.asOpt[JsObject]).getOrElse(Json.obj())
     val impacts = attrs.get(ChatClientWithEcoImpact.key)
     val costs = attrs.get(ChatClientWithCostsTracking.key)
@@ -101,7 +101,7 @@ class ChatClientWithAuditing(originalProvider: AiProvider, val chatClient: ChatC
     attrs.put(ChatClientWithAuding.ModelKey -> originalBody.select("model").asOptString.orElse(originalProvider.options.select("model").asOptString).getOrElse("--"))
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val consumedUsing = kind.consumedUsing(streaming = false)
     prepare(attrs, originalBody)
     AiBudgetsDataStore.handleWithinBudget(attrs)(
@@ -114,7 +114,7 @@ class ChatClientWithAuditing(originalProvider: AiProvider, val chatClient: ChatC
     )
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val consumedUsing = kind.consumedUsing(streaming = true)
     prepare(attrs, originalBody)
     AiBudgetsDataStore.handleWithinBudget(attrs)(
@@ -168,7 +168,7 @@ class ChatClientWithAuditing(originalProvider: AiProvider, val chatClient: ChatC
 // so front-ends can report token counts on any streaming endpoint (`/responses` included).
 class ChatClientWithStreamUsage(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     chatClient.invokeStream(kind, prompt, attrs, originalBody).map {
       case Left(err) => Left(err)
       case Right(resp) => {
@@ -214,7 +214,7 @@ object EmbeddingModelClientWithAuditing {
 
 class EmbeddingModelClientWithAuditing(originalModel: EmbeddingModel, val embeddingModelClient: EmbeddingModelClient) extends DecoratorEmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -278,7 +278,6 @@ class EmbeddingModelClientWithAuditing(originalModel: EmbeddingModel, val embedd
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-embedding" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-embedding" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -315,7 +314,7 @@ object AudioModelClientWithAuditing {
 
 class AudioModelClientWithAuditing(originalModel: AudioModel, val audioModelClient: AudioModelClient) extends DecoratorAudioModelClient {
 
-  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -379,7 +378,6 @@ class AudioModelClientWithAuditing(originalModel: AudioModel, val audioModelClie
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-audio" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-audio" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -407,7 +405,7 @@ class AudioModelClientWithAuditing(originalModel: AudioModel, val audioModelClie
     )
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -471,7 +469,6 @@ class AudioModelClientWithAuditing(originalModel: AudioModel, val audioModelClie
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-audio" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-audio" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -500,7 +497,7 @@ class AudioModelClientWithAuditing(originalModel: AudioModel, val audioModelClie
   }
 
   // no metrics right now !!!
-  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = super.textToSpeech(options, rawBody, attrs)
+  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = super.textToSpeech(options, rawBody, attrs)
 }
 
 object ImageModelClientWithAuditing {
@@ -511,7 +508,7 @@ object ImageModelClientWithAuditing {
 
 class ImageModelClientWithAuditing(originalModel: ImageModel, val imageModelClient: ImageModelClient) extends DecoratorImageModelClient {
 
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -575,7 +572,6 @@ class ImageModelClientWithAuditing(originalModel: ImageModel, val imageModelClie
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-image" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-image" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -603,7 +599,7 @@ class ImageModelClientWithAuditing(originalModel: ImageModel, val imageModelClie
     )
   }
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -667,7 +663,6 @@ class ImageModelClientWithAuditing(originalModel: ImageModel, val imageModelClie
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-image" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-image" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -704,7 +699,7 @@ object ModerationModelClientWithAuditing {
 
 class ModerationModelClientWithAuditing(originalModel: ModerationModel, val moderationModelClient: ModerationModelClient) extends DecoratorModerationModelClient {
 
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -768,7 +763,6 @@ class ModerationModelClientWithAuditing(originalModel: ModerationModel, val mode
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-moderation" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-moderation" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -805,7 +799,7 @@ object VideoModelClientWithAuditing {
 
 class VideoModelClientWithAuditing(originalModel: VideoModel, val videoModelClient: VideoModelClient) extends DecoratorVideoModelClient {
 
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -869,7 +863,6 @@ class VideoModelClientWithAuditing(originalModel: VideoModel, val videoModelClie
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-video" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-video" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {
@@ -906,7 +899,7 @@ object OcrModelClientWithAuditing {
 
 class OcrModelClientWithAuditing(originalModel: OcrModel, val ocrModelClient: OcrModelClient) extends DecoratorOcrModelClient {
 
-  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
+  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
     val startTime = System.currentTimeMillis()
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -970,7 +963,6 @@ class OcrModelClientWithAuditing(originalModel: OcrModel, val ocrModelClient: Oc
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai-ocr" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai-ocr" -> Seq(slug))
             }
             AuditEvent.generic("LLMUsageAudit") {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/circuitbreaker.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/circuitbreaker.scala
@@ -4,7 +4,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.AiMetrics
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
 import otoroshi.utils.cache.types.UnboundedTrieMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 
 // Per-provider circuit breaker settings, read from the provider options under `circuit_breaker`.
 // Opt-in: disabled unless `circuit_breaker.enabled = true`, so existing providers are unaffected.
@@ -43,13 +43,13 @@ object ProviderCircuitBreaker {
     states.get(providerId).exists(_.openUntil > now)
   }
 
-  def recordSuccess(providerId: String)(implicit env: Env): Unit = states.synchronized {
+  def recordSuccess(providerId: String)(using env: Env): Unit = states.synchronized {
     val wasOpen = states.get(providerId).exists(_.openUntil > 0L)
     states.remove(providerId)
     if (wasOpen) AiMetrics.markCircuit("close")
   }
 
-  def recordFailure(providerId: String, now: Long, settings: CircuitBreakerSettings)(implicit env: Env): Unit = states.synchronized {
+  def recordFailure(providerId: String, now: Long, settings: CircuitBreakerSettings)(using env: Env): Unit = states.synchronized {
     val failures = states.get(providerId).map(_.failures).getOrElse(0) + 1
     val openUntil = if (failures >= settings.consecutiveFailures) now + settings.cooldownMs else 0L
     states.update(providerId, State(failures, openUntil))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/context.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/context.scala
@@ -1,13 +1,13 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatMessage, ChatMessageContentFlavor, ChatPrompt, ChatResponse, ChatResponseChunk}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, PromptContext}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.json.JsValue
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -30,7 +30,7 @@ class ChatClientWithContext(originalProvider: AiProvider, val chatClient: ChatCl
       }
   }
 
-  private def getNewPrompt(prompt: ChatPrompt, originalBody: JsValue)(implicit env: Env): ChatPrompt = {
+  private def getNewPrompt(prompt: ChatPrompt, originalBody: JsValue)(using env: Env): ChatPrompt = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val possibleContextList = originalProvider.context.contexts.flatMap(ref => ext.states.context(ref))
     lazy val possibleContextById = possibleContextList.map(c => (c.id, c)).toMap
@@ -62,12 +62,12 @@ class ChatClientWithContext(originalProvider: AiProvider, val chatClient: ChatCl
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val newPrompt = getNewPrompt(prompt, originalBody)
     chatClient.invoke(kind, newPrompt, attrs, originalBody.asObject - "context")
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val newPrompt = getNewPrompt(prompt, originalBody)
     chatClient.invokeStream(kind, newPrompt, attrs, originalBody.asObject - "context")
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/costs.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/costs.scala
@@ -1,14 +1,14 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.{Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk, ChatResponseChunkChoice, ChatResponseChunkChoiceDelta}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
 import play.api.Configuration
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.typedmap.TypedKey
@@ -16,6 +16,7 @@ import play.api.libs.typedmap.TypedKey
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.DurationInt
+import org.apache.pekko.stream.Materializer
 
 case class CostsTrackingSettings(configuration: Configuration) {
   val embedDescriptionInJson = configuration.getOptional[Boolean]("embed-description-in-json").getOrElse(true)
@@ -122,8 +123,8 @@ class CostsTracking(settings: CostsTrackingSettings, env: Env) {
   val models: Map[String, CostModel] = litllmModels ++ customModels ++ userProvidedModels
 
   def getResourceCode(path: String): String = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
     env.environment.resourceAsStream(path)
       .map(stream => StreamConverters.fromInputStream(() => stream).runFold(ByteString.empty)(_++_).awaitf(10.seconds).utf8String)
       .getOrElse(s"'resource ${path} not found !'")
@@ -206,11 +207,11 @@ class ChatClientWithCostsTracking(originalProvider: AiProvider, val chatClient: 
     if (allowConfigOverride) originalBody.select("model").asOptString.getOrElse(chatClient.computeModel(originalBody).getOrElse("--")) else chatClient.computeModel(originalBody).getOrElse("--")
   }
 
-  def getProvider()(implicit env: Env): Option[String] = {
+  def getProvider()(using env: Env): Option[String] = {
     env.adminExtensions.extension[AiExtension].flatMap(ext => ext.costsTracking.getProvider(originalProvider.provider))
   }
 
-  private def handleStream(attrs: TypedMap, originalBody: JsValue)(f: => Future[Either[JsValue, Source[ChatResponseChunk, _]]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def handleStream(attrs: TypedMap, originalBody: JsValue)(f: => Future[Either[JsValue, Source[ChatResponseChunk, ?]]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     getProvider() match {
       case None => f // unsupported provider
       case Some(provider) => {
@@ -225,7 +226,7 @@ class ChatClientWithCostsTracking(originalProvider: AiProvider, val chatClient: 
             val budgetInRequest = attrs.get(otoroshi.plugins.Keys.RequestKey).flatMap(_.getQueryString("embed_budget")).contains("true")
             val addCostsInResp = ext.costsTrackingSettings.embedCostsTrackingInResponses || enableInRequest
             if (ext.costsTracking.canHandle(finalProvider, model)) {
-              resp.applyOnIf(addCostsInResp) { src =>
+              (resp: Source[ChatResponseChunk, Any]).applyOnIf(addCostsInResp) { src =>
                 src.map(r => r.copy(choices = r.choices.map(c => c.copy(finishReason = None))))
               }.alsoTo(Sink.onComplete { _ =>
                 val usageSlug: JsObject = attrs.get(otoroshi.plugins.Keys.ExtraAnalyticsDataKey).flatMap(_.select("ai").asOpt[Seq[JsObject]]).flatMap(_.lastOption).flatMap(_.asOpt[JsObject]).getOrElse(Json.obj())
@@ -268,7 +269,7 @@ class ChatClientWithCostsTracking(originalProvider: AiProvider, val chatClient: 
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val budgetInRequest = attrs.get(otoroshi.plugins.Keys.RequestKey).flatMap(_.getQueryString("embed_budget")).contains("true")
     getProvider() match {
       case None => chatClient.invoke(kind, prompt, attrs, originalBody) // unsupported provider
@@ -285,7 +286,7 @@ class ChatClientWithCostsTracking(originalProvider: AiProvider, val chatClient: 
               outputTokens = usage.generationTokens,
               reasoningTokens = usage.reasoningTokens
             ) match {
-              case Left(err) =>
+              case Left(_) =>
                 Right(resp.copy(metadata = resp.metadata.copy(budget = attrs.get(ChatClientWithAuding.BudgetConsumptionKey).filter(_ => ext.embedBudgetsInResponses || budgetInRequest))))
               case Right(costs) => {
                 attrs.put(ChatClientWithCostsTracking.key -> costs)
@@ -303,7 +304,7 @@ class ChatClientWithCostsTracking(originalProvider: AiProvider, val chatClient: 
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     handleStream(attrs, originalBody) {
       chatClient.invokeStream(kind, prompt, attrs, originalBody)
     }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/decorators.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/decorators.scala
@@ -1,9 +1,9 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.entities._
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.*
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
 import play.api.libs.json.{JsObject, JsValue}
@@ -51,9 +51,9 @@ trait DecoratorChatClient extends KindBasedChatClient {
   override def supportsTools: Boolean = chatClient.supportsTools
   override def supportsCompletion: Boolean = chatClient.supportsCompletion
   override def supportsResponses: Boolean = chatClient.supportsResponses
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = chatClient.listModels(raw, attrs)
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = chatClient.invoke(kind, prompt, attrs, originalBody)
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = chatClient.invokeStream(kind, prompt, attrs, originalBody)
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = chatClient.listModels(raw, attrs)
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = chatClient.invoke(kind, prompt, attrs, originalBody)
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = chatClient.invokeStream(kind, prompt, attrs, originalBody)
 }
 
 object EmbeddingModelClientDecorators {
@@ -73,7 +73,7 @@ object EmbeddingModelClientDecorators {
 
 trait DecoratorEmbeddingModelClient extends EmbeddingModelClient {
   def embeddingModelClient: EmbeddingModelClient
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     embeddingModelClient.embed(opts, rawBody, attrs)
   }
 }
@@ -97,11 +97,11 @@ trait DecoratorAudioModelClient extends AudioModelClient {
   override def supportsStt: Boolean = audioModelClient.supportsStt
   override def supportsTts: Boolean = audioModelClient.supportsTts
   override def supportsTranslation: Boolean = audioModelClient.supportsTranslation
-  override def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = audioModelClient.translate(options, rawBody, attrs)
-  override def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = audioModelClient.speechToText(options, rawBody, attrs)
-  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = audioModelClient.textToSpeech(options, rawBody, attrs)
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = audioModelClient.listModels(raw)
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = audioModelClient.listVoices(raw)
+  override def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = audioModelClient.translate(options, rawBody, attrs)
+  override def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = audioModelClient.speechToText(options, rawBody, attrs)
+  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = audioModelClient.textToSpeech(options, rawBody, attrs)
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = audioModelClient.listModels(raw)
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = audioModelClient.listVoices(raw)
 }
 
 object ImageModelClientDecorators {
@@ -122,13 +122,13 @@ trait DecoratorImageModelClient extends ImageModelClient {
   def imageModelClient: ImageModelClient
   override def supportsEdit: Boolean = imageModelClient.supportsEdit
   override def supportsGeneration: Boolean = imageModelClient.supportsGeneration
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = super.generate(opts, rawBody, attrs)
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = super.edit(opts, rawBody, attrs)
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = super.generate(opts, rawBody, attrs)
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = super.edit(opts, rawBody, attrs)
 }
 
 trait DecoratorModerationModelClient extends ModerationModelClient {
   def moderationModelClient: ModerationModelClient
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = moderationModelClient.moderate(opts, rawBody, attrs)
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = moderationModelClient.moderate(opts, rawBody, attrs)
 }
 
 object ModerationModelClientDecorators {
@@ -148,7 +148,7 @@ object ModerationModelClientDecorators {
 trait DecoratorVideoModelClient extends VideoModelClient {
   def videoModelClient: VideoModelClient
   override def supportsTextToVideo: Boolean = videoModelClient.supportsTextToVideo
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = videoModelClient.generate(opts, rawBody, attrs)
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = videoModelClient.generate(opts, rawBody, attrs)
 }
 
 object VideosGenModelClientDecorators {
@@ -168,8 +168,8 @@ object VideosGenModelClientDecorators {
 trait DecoratorOcrModelClient extends OcrModelClient {
   def ocrModelClient: OcrModelClient
   override def supportsOcr: Boolean = ocrModelClient.supportsOcr
-  override def ocr(options: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = ocrModelClient.ocr(options, rawBody, attrs)
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = ocrModelClient.listModels(raw)
+  override def ocr(options: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = ocrModelClient.ocr(options, rawBody, attrs)
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = ocrModelClient.listModels(raw)
 }
 
 object OcrModelClientDecorators {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/ecologits.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/ecologits.scala
@@ -1,25 +1,26 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.{Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.Types.ValueOrRange
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk, ChatResponseChunkChoice, ChatResponseChunkChoiceDelta}
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.Configuration
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedKey
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.math._
-import scala.util._
+import scala.math.*
+import scala.util.*
+import org.apache.pekko.stream.Materializer
 
 /**
  * This code is a scala port of the [EcoLogits](https://github.com/genai-impact/ecologits) project
@@ -244,7 +245,7 @@ object LLMImpactModel {
     val gpuTotalEnergy = ValueOrRange * (gpuEnergy, gpuRequiredCount.toDouble)
     ValueOrRange * (gpuTotalEnergy, pue) match {
       case total => ValueOrRange * (Left(serverEnergy), pue) match {
-        case Right(serverPart) => Right(RangeValue(serverPart.min + total.right.get.min, serverPart.max + total.right.get.max))
+        case Right(serverPart) => Right(RangeValue(serverPart.min + total.toOption.get.min, serverPart.max + total.toOption.get.max))
         case Left(serverPart) =>
           total match {
             case Left(gpuPart)   => Left(serverPart + gpuPart)
@@ -641,8 +642,8 @@ class LLMImpacts(settings: LLMImpactsSettings, env: Env) {
   val electricityMixes = default_electricityMixes ++ custom_electricityMixes ++ user_electricityMixes
 
   def getResourceCode(path: String): String = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
     env.environment.resourceAsStream(path)
       .map(stream => StreamConverters.fromInputStream(() => stream).runFold(ByteString.empty)(_++_).awaitf(10.seconds).utf8String)
       .getOrElse(s"'resource ${path} not found !'")
@@ -752,7 +753,7 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
     }
   }
 
-  private def handleStream(attrs: TypedMap, originalBody: JsValue)(f: => Future[Either[JsValue, Source[ChatResponseChunk, _]]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def handleStream(attrs: TypedMap, originalBody: JsValue)(f: => Future[Either[JsValue, Source[ChatResponseChunk, ?]]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     getProvider() match {
       case None => f // unsupported provider
       case Some(provider) => {
@@ -767,7 +768,7 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
             val enableInRequest = attrs.get(otoroshi.plugins.Keys.RequestKey).flatMap(_.getQueryString("embed_impacts")).contains("true")
             val addCostsInResp = ext.llmImpactsSettings.embedImpactsInResponses || enableInRequest
             if (ext.llmImpacts.canHandle(finalProvider, modelName)) {
-              resp.applyOnIf(addCostsInResp) { src =>
+              (resp: Source[ChatResponseChunk, Any]).applyOnIf(addCostsInResp) { src =>
                 src.map(r => r.copy(choices = r.choices.map(c => c.copy(finishReason = None))))
               }.alsoTo(Sink.onComplete { _ =>
                 val usageSlug: JsObject = attrs.get(otoroshi.plugins.Keys.ExtraAnalyticsDataKey).flatMap(_.select("ai").asOpt[Seq[JsObject]]).flatMap(_.headOption).flatMap(_.asOpt[JsObject]).getOrElse(Json.obj())
@@ -778,7 +779,7 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
                   provider = finalProvider,
                   modelName = modelName,
                   outputTokenCount = (generationTokens + reasoningTokens).toInt,
-                  requestLatency = System.currentTimeMillis() - start,
+                  requestLatency = (System.currentTimeMillis() - start).toDouble,
                   electricityMixZoneOpt = originalProvider.metadata.get("eco-impacts-electricity-mix-zone"),
                 ) match {
                   case Left(_) => promise.trySuccess(None)
@@ -810,7 +811,7 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     getProvider() match {
       case None => chatClient.invoke(kind, prompt, attrs, originalBody) // unsupported provider
       case Some(provider) => {
@@ -824,10 +825,10 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
               provider = originalProvider.metadata.getOrElse("eco-impacts-provider", provider),
               modelName = originalProvider.metadata.getOrElse("eco-impacts-model", getModel(originalBody)),
               outputTokenCount = (usage.generationTokens + usage.reasoningTokens).toInt,
-              requestLatency = System.currentTimeMillis() - start,
+              requestLatency = (System.currentTimeMillis() - start).toDouble,
               electricityMixZoneOpt = originalProvider.metadata.get("eco-impacts-electricity-mix-zone"),
             ) match {
-              case Left(err) => Right(resp)
+              case Left(_) => Right(resp)
               case Right(impacts) => {
                 attrs.put(ChatClientWithEcoImpact.key -> impacts)
                 // impacts.json(ext.llmImpactsSettings.embedDescriptionInJson).prettify.debugPrintln
@@ -845,7 +846,7 @@ class ChatClientWithEcoImpact(originalProvider: AiProvider, val chatClient: Chat
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     handleStream(attrs, originalBody) {
       chatClient.invokeStream(kind, prompt, attrs, originalBody)
     }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/fallback.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/fallback.scala
@@ -1,11 +1,11 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{AiMetrics, ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsValue, Json}
 
@@ -23,7 +23,7 @@ object ChatClientWithProviderFallback {
 
 class ChatClientWithProviderFallback(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
 
-  private def fallbackClient()(implicit env: Env): Option[ChatClient] = {
+  private def fallbackClient()(using env: Env): Option[ChatClient] = {
     env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(originalProvider.providerFallback.get)).flatMap(_.getChatClient())
   }
 
@@ -31,7 +31,7 @@ class ChatClientWithProviderFallback(originalProvider: AiProvider, val chatClien
   // (Left or exception). When the per-provider circuit breaker is enabled and the primary's circuit
   // is open, the primary is skipped entirely and we go straight to the fallback (fail fast). Primary
   // outcomes feed the breaker (success closes the circuit, failures eventually open it).
-  private def withFallback[T](op: ChatClient => Future[Either[JsValue, T]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
+  private def withFallback[T](op: ChatClient => Future[Either[JsValue, T]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
     val settings = CircuitBreakerSettings.fromProvider(originalProvider)
 
     def callFallback(err: JsValue): Future[Either[JsValue, T]] = {
@@ -60,11 +60,11 @@ class ChatClientWithProviderFallback(originalProvider: AiProvider, val chatClien
     }
   }
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     withFallback(_.invoke(kind, originalPrompt, attrs, originalBody))
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     withFallback(_.invokeStream(kind, originalPrompt, attrs, originalBody))
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/guardrails.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/guardrails.scala
@@ -1,12 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{AiMetrics, ChatCallKind, ChatClient, ChatGeneration, ChatMessage, ChatPrompt, ChatResponse, ChatResponseChunk, ChatResponseMetadata, InputChatMessage, OutputChatMessage}
-import com.cloud.apim.otoroshi.extensions.aigateway.guardrails._
+import com.cloud.apim.otoroshi.extensions.aigateway.guardrails.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{Format, JsArray, JsError, JsObject, JsResult, JsSuccess, JsValue, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -76,7 +76,7 @@ case class Guardrails(items: Seq[GuardrailItem]) {
   def isEmpty: Boolean = items.isEmpty
   def json: JsValue = Guardrails.format.writes(this)
 
-  def call(callPhase: GuardrailsCallPhase, messages: Seq[ChatMessage], originalProvider: AiProvider, chatClient: ChatClient, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  def call(callPhase: GuardrailsCallPhase, messages: Seq[ChatMessage], originalProvider: AiProvider, chatClient: ChatClient, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
 
     val allGuardrails = originalProvider.guardrails.items.filter(_.enabled).flatMap { item =>
       Guardrails.possibleGuardrails.get(item.guardrailId).map(guardrail => (item, guardrail))
@@ -192,7 +192,7 @@ trait Guardrail {
   def isBefore: Boolean
   def isAfter: Boolean
   def manyMessages: Boolean
-  def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult]
+  def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult]
 }
 
 class ChatClientWithGuardrailsValidation(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
@@ -205,7 +205,7 @@ class ChatClientWithGuardrailsValidation(originalProvider: AiProvider, val chatC
 
   // resolves the Before phase: Left = short-circuit result to render (deny/error),
   // Right = the effective prompt to forward (original on pass, rewritten on transform)
-  private def resolveBefore(originalPrompt: ChatPrompt, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[GuardrailResult, ChatPrompt]] = {
+  private def resolveBefore(originalPrompt: ChatPrompt, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[GuardrailResult, ChatPrompt]] = {
     originalProvider.guardrails.call(GuardrailsCallPhase.Before, originalPrompt.messages, originalProvider, chatClient, attrs).map {
       case GuardrailResult.GuardrailPass => Right(originalPrompt)
       case GuardrailResult.GuardrailTransform(newMessages) => Right(originalPrompt.copy(messages = newMessages.collect { case i: InputChatMessage => i }))
@@ -214,7 +214,7 @@ class ChatClientWithGuardrailsValidation(originalProvider: AiProvider, val chatC
   }
 
   // runs the After phase on a (non-streamed) response, re-inflating placeholders when a guardrail transforms the output
-  private def runAfter(r: ChatResponse, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def runAfter(r: ChatResponse, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     originalProvider.guardrails.call(GuardrailsCallPhase.After, r.generations.map(_.message), originalProvider, chatClient, attrs).map {
       case GuardrailResult.GuardrailError(err) => Left(Json.obj("error" -> "bad_request", "error_description" -> err, "phase" -> "after"))
       case GuardrailResult.GuardrailDenied(msg) if originalProvider.guardrailsFailOnDeny => Left(Json.obj("error" -> "guardrail_denied", "error_description" -> msg, "phase" -> "after"))
@@ -230,7 +230,7 @@ class ChatClientWithGuardrailsValidation(originalProvider: AiProvider, val chatC
     }
   }
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     resolveBefore(originalPrompt, attrs).flatMap {
       case Left(GuardrailResult.GuardrailError(err)) => Left(Json.obj("error" -> "bad_request", "error_description" -> err, "phase" -> "before")).vfuture
       case Left(GuardrailResult.GuardrailDenied(msg)) if originalProvider.guardrailsFailOnDeny => Left(Json.obj("error" -> "guardrail_denied", "error_description" -> msg, "phase" -> "before")).vfuture
@@ -243,7 +243,7 @@ class ChatClientWithGuardrailsValidation(originalProvider: AiProvider, val chatC
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     resolveBefore(originalPrompt, attrs).flatMap {
       case Left(GuardrailResult.GuardrailError(err)) => Left(Json.obj("error" -> "bad_request", "error_description" -> err, "phase" -> "before")).vfuture
       case Left(GuardrailResult.GuardrailDenied(msg)) => Right(deniedResponse(msg).toSource(originalBody.select("model").asOpt[String].getOrElse("model"))).vfuture

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/loadbalancer.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/loadbalancer.scala
@@ -1,12 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk, KindBasedChatClient}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
 import otoroshi.utils.cache.types.UnboundedTrieMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsBoolean, JsDefined, JsLookupResult, JsNull, JsNumber, JsObject, JsString, JsUndefined, JsValue, Json}
 
@@ -15,12 +15,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait LoadBalancing {
-  def select(reqId: String, targets: Seq[AiProvider])(implicit env: Env): AiProvider
+  def select(reqId: String, targets: Seq[AiProvider])(using env: Env): AiProvider
 }
 
 object RoundRobin extends LoadBalancing {
   private val reqCounter                   = new AtomicInteger(0)
-  override def select(reqId: String, targets: Seq[AiProvider])(implicit env: Env): AiProvider = {
+  override def select(reqId: String, targets: Seq[AiProvider])(using env: Env): AiProvider = {
     val index: Int = reqCounter.incrementAndGet() % (if (targets.nonEmpty) targets.size else 1)
     targets.apply(index)
   }
@@ -28,7 +28,7 @@ object RoundRobin extends LoadBalancing {
 
 object Random extends LoadBalancing {
   private val random = new scala.util.Random
-  override def select(reqId: String, targets: Seq[AiProvider])(implicit env: Env): AiProvider = {
+  override def select(reqId: String, targets: Seq[AiProvider])(using env: Env): AiProvider = {
     val index = random.nextInt(targets.length)
     targets.apply(index)
   }
@@ -78,7 +78,7 @@ object BestResponseTime extends LoadBalancing {
     window.record(System.currentTimeMillis(), responseTime)
   }
 
-  override def select(reqId: String, targets: Seq[AiProvider])(implicit env: Env): AiProvider = {
+  override def select(reqId: String, targets: Seq[AiProvider])(using env: Env): AiProvider = {
     if (targets.isEmpty) throw new IllegalArgumentException("no targets to load balance on")
     val now = System.currentTimeMillis()
     val scored: Seq[(AiProvider, Option[Long])] = targets.map { t =>
@@ -106,7 +106,7 @@ class LoadBalancerChatClient(provider: AiProvider) extends KindBasedChatClient {
   override def isOpenAi: Boolean = true
   override def isAnthropic: Boolean = false
 
-  def execute[T](prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(f: (AiProvider, ChatClient) => Future[Either[JsValue, T]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
+  def execute[T](prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(f: (AiProvider, ChatClient) => Future[Either[JsValue, T]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
     val refs: Seq[LoadBalancingTarget] = provider.options.select("refs")
       .asOpt[Seq[String]].map { seq =>
         seq.map(i => LoadBalancingTarget(i, 1, None))
@@ -184,7 +184,7 @@ class LoadBalancerChatClient(provider: AiProvider) extends KindBasedChatClient {
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     execute(prompt, attrs, originalBody) { (selected, client) =>
       val start = System.currentTimeMillis()
       client.invoke(kind, prompt, attrs, originalBody).map { resp =>
@@ -194,7 +194,7 @@ class LoadBalancerChatClient(provider: AiProvider) extends KindBasedChatClient {
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     execute(prompt, attrs, originalBody) { (selected, client) =>
       val start = System.currentTimeMillis()
       client.invokeStream(kind, prompt, attrs, originalBody).map { resp =>

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/logging.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/logging.scala
@@ -1,6 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import io.azam.ulidj.ULID
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 
 object ChatClientWithRequestResponseLogging {
 
@@ -96,7 +96,7 @@ class ChatClientWithRequestResponseLogging(originalProvider: AiProvider, val cha
 
   // ---- blocking -----------------------------------------------------------
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val requestedAt = now()
     val logKind = s"${kind.name}/call"
     writeEntry(baseFields ++ Json.obj(
@@ -129,7 +129,7 @@ class ChatClientWithRequestResponseLogging(originalProvider: AiProvider, val cha
 
   // ---- stream -------------------------------------------------------------
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val requestedAt = now()
     val logKind = s"${kind.name}/stream"
     writeEntry(baseFields ++ Json.obj(

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/memory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/memory.scala
@@ -1,17 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.el.GlobalExpressionLanguage
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, JsValue, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.tools.nsc.Global
 
 object ChatClientWithPersistentMemory {
   def applyIfPossible(tuple: (AiProvider, ChatClient, Env)): ChatClient = {
@@ -26,7 +25,7 @@ object ChatClientWithPersistentMemory {
 class ChatClientWithPersistentMemory(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
 
   // resolves the memory client and the session id, then hands them to `f`
-  private def withMemory[T](attrs: TypedMap)(f: (PersistentMemoryClient, String) => Future[Either[JsValue, T]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
+  private def withMemory[T](attrs: TypedMap)(f: (PersistentMemoryClient, String) => Future[Either[JsValue, T]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
     val ref = originalProvider.memory.get
     env.adminExtensions.extension[AiExtension].get.states.persistentMemory(ref) match {
       case None => Json.obj("error" -> "memory provider not found").leftf
@@ -52,7 +51,7 @@ class ChatClientWithPersistentMemory(originalProvider: AiProvider, val chatClien
     }
   }
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     withMemory[ChatResponse](attrs) { (memClient, sessionId) =>
       memClient.getMessages(sessionId).flatMap {
         case Left(error) => error.leftf
@@ -75,8 +74,8 @@ class ChatClientWithPersistentMemory(originalProvider: AiProvider, val chatClien
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
-    withMemory[Source[ChatResponseChunk, _]](attrs) { (memClient, sessionId) =>
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
+    withMemory[Source[ChatResponseChunk, ?]](attrs) { (memClient, sessionId) =>
       memClient.getMessages(sessionId).flatMap {
         case Left(error) => error.leftf
         case Right(memoryMessages) => {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/metricsdecorators.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/metricsdecorators.scala
@@ -1,8 +1,8 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, AudioModel, EmbeddingModel, ImageModel, ModerationModel, VideoModel}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
@@ -16,12 +16,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ChatClientWithMetrics(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
 
-  private def markChatTokensAndCost(attrs: TypedMap)(implicit env: Env): Unit = {
+  private def markChatTokensAndCost(attrs: TypedMap)(using env: Env): Unit = {
     attrs.get(ChatClient.ApiUsageKey).foreach(m => AiMetrics.markTokens(m.usage.promptTokens.toInt, m.usage.generationTokens.toInt, m.usage.reasoningTokens.toInt))
     attrs.get(ChatClientWithCostsTracking.key).foreach(c => AiMetrics.markCost(c.totalCost.toDouble))
   }
 
-  private def meterBlocking(op: String, attrs: TypedMap, f: Future[Either[JsValue, ChatResponse]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def meterBlocking(op: String, attrs: TypedMap, f: Future[Either[JsValue, ChatResponse]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around(op, originalProvider.provider.toLowerCase, start, f) { resp =>
       markChatTokensAndCost(attrs)
@@ -30,7 +30,7 @@ class ChatClientWithMetrics(originalProvider: AiProvider, val chatClient: ChatCl
     }
   }
 
-  private def meterStreaming(op: String, attrs: TypedMap, f: Future[Either[JsValue, Source[ChatResponseChunk, _]]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def meterStreaming(op: String, attrs: TypedMap, f: Future[Either[JsValue, Source[ChatResponseChunk, ?]]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val start = System.currentTimeMillis()
     // token/cost are only known once the stream completes; duration recorded by around is time-to-stream-start
     val wrapped = f.map {
@@ -40,10 +40,10 @@ class ChatClientWithMetrics(originalProvider: AiProvider, val chatClient: ChatCl
     AiMetrics.around(op, originalProvider.provider.toLowerCase, start, wrapped) { _ => () }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] =
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] =
     meterBlocking(kind.metricsOp(streaming = false), attrs, chatClient.invoke(kind, prompt, attrs, originalBody))
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] =
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] =
     meterStreaming(kind.metricsOp(streaming = true), attrs, chatClient.invokeStream(kind, prompt, attrs, originalBody))
 }
 
@@ -52,7 +52,7 @@ object ChatClientWithMetrics {
 }
 
 class EmbeddingModelClientWithMetrics(originalModel: EmbeddingModel, val embeddingModelClient: EmbeddingModelClient) extends DecoratorEmbeddingModelClient {
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("embedding_model.embedding", originalModel.provider.toLowerCase, start, embeddingModelClient.embed(opts, rawBody, attrs)) { _ =>
       attrs.get(EmbeddingModelClient.ApiUsageKey).foreach(m => AiMetrics.markTokens(m.tokenUsage.toInt, 0, 0))
@@ -66,15 +66,15 @@ object EmbeddingModelClientWithMetrics {
 
 class AudioModelClientWithMetrics(originalModel: AudioModel, val audioModelClient: AudioModelClient) extends DecoratorAudioModelClient {
   private val kind = originalModel.provider.toLowerCase
-  override def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("audio_model.translate", kind, start, audioModelClient.translate(options, rawBody, attrs)) { _ => () }
   }
-  override def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("audio_model.stt", kind, start, audioModelClient.speechToText(options, rawBody, attrs)) { _ => () }
   }
-  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("audio_model.tts", kind, start, audioModelClient.textToSpeech(options, rawBody, attrs)) { _ => () }
   }
@@ -86,11 +86,11 @@ object AudioModelClientWithMetrics {
 
 class ImageModelClientWithMetrics(originalModel: ImageModel, val imageModelClient: ImageModelClient) extends DecoratorImageModelClient {
   private val kind = originalModel.provider.toLowerCase
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("image_model.generate", kind, start, imageModelClient.generate(opts, rawBody, attrs)) { _ => () }
   }
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("image_model.edit", kind, start, imageModelClient.edit(opts, rawBody, attrs)) { _ => () }
   }
@@ -101,7 +101,7 @@ object ImageModelClientWithMetrics {
 }
 
 class ModerationModelClientWithMetrics(originalModel: ModerationModel, val moderationModelClient: ModerationModelClient) extends DecoratorModerationModelClient {
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("moderation_model.moderate", originalModel.provider.toLowerCase, start, moderationModelClient.moderate(opts, rawBody, attrs)) { _ => () }
   }
@@ -112,7 +112,7 @@ object ModerationModelClientWithMetrics {
 }
 
 class VideoModelClientWithMetrics(originalModel: VideoModel, val videoModelClient: VideoModelClient) extends DecoratorVideoModelClient {
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     val start = System.currentTimeMillis()
     AiMetrics.around("video_model.generate", originalModel.provider.toLowerCase, start, videoModelClient.generate(opts, rawBody, attrs)) { _ => () }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/mock.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/mock.scala
@@ -1,12 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.Source
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
 import otoroshi.security.IdGenerator
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsValue, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,7 +40,7 @@ class ChatClientWithMockResponse(val chatClient: ChatClient) extends DecoratorCh
 
   private def mockResponse(originalBody: JsValue): Option[String] = originalBody.select("mock_response").asOpt[String]
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     mockResponse(originalBody) match {
       case Some(mock) if mock.startsWith(ChatClientWithMockResponse.exceptionPrefix) =>
         Future.successful(Left(ChatClientWithMockResponse.mockError(mock.drop(ChatClientWithMockResponse.exceptionPrefix.length).trim)))
@@ -59,7 +59,7 @@ class ChatClientWithMockResponse(val chatClient: ChatClient) extends DecoratorCh
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     mockResponse(originalBody) match {
       case Some(mock) if mock.startsWith(ChatClientWithMockResponse.exceptionPrefix) =>
         Future.successful(Left(ChatClientWithMockResponse.mockError(mock.drop(ChatClientWithMockResponse.exceptionPrefix.length).trim)))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/models.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/models.scala
@@ -1,13 +1,13 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.AiMetrics
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, AudioModel, EmbeddingModel, ImageModel, ModelSettings, ModerationModel, VideoModel}
-import com.cloud.apim.otoroshi.extensions.aigateway.{AudioGenModel, AudioGenVoice, AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions, AudioTranscriptionResponse, ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk, EmbeddingClientInputOptions, EmbeddingModelClient, EmbeddingResponse, ImageModelClient, ImageModelClientEditionInputOptions, ImageModelClientGenerationInputOptions, ImagesGenResponse, ModerationModelClient, ModerationModelClientInputOptions, ModerationResponse, VideoModelClient, VideoModelClientTextToVideoInputOptions, VideosGenResponse}
+import com.cloud.apim.otoroshi.extensions.aigateway.{AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions, AudioTranscriptionResponse, ChatCallKind, ChatClient, ChatPrompt, ChatResponse, ChatResponseChunk, EmbeddingClientInputOptions, EmbeddingModelClient, EmbeddingResponse, ImageModelClient, ImageModelClientEditionInputOptions, ImageModelClientGenerationInputOptions, ImagesGenResponse, ModerationModelClient, ModerationModelClientInputOptions, ModerationResponse, VideoModelClient, VideoModelClientTextToVideoInputOptions, VideosGenResponse}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsObject, JsValue, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -25,7 +25,7 @@ object ChatClientWithModelConstraints {
 class ChatClientWithModelConstraints(originalProvider: AiProvider, val chatClient: ChatClient) extends DecoratorChatClient {
 
   // Left when the requested model is outside the allow-list of the provider, the apikey or the user
-  private def checkModel(originalBody: JsValue, attrs: TypedMap)(implicit env: Env): Either[JsValue, Unit] = {
+  private def checkModel(originalBody: JsValue, attrs: TypedMap)(using env: Env): Either[JsValue, Unit] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     originalBody.select("model").asOptString.orElse(chatClient.computeModel(originalBody)) match {
@@ -35,21 +35,21 @@ class ChatClientWithModelConstraints(originalProvider: AiProvider, val chatClien
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     checkModel(originalBody, attrs) match {
       case Left(err) => err.leftf
       case Right(_) => chatClient.invoke(kind, prompt, attrs, originalBody)
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     checkModel(originalBody, attrs) match {
       case Left(err) => err.leftf
       case Right(_) => chatClient.invokeStream(kind, prompt, attrs, originalBody)
     }
   }
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     chatClient.listModels(raw, attrs).map {
@@ -75,7 +75,7 @@ object EmbeddingModelClientWithModels {
 }
 
 class EmbeddingModelClientWithModels(originalModel: EmbeddingModel, val embeddingModelClient: EmbeddingModelClient) extends DecoratorEmbeddingModelClient {
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -94,7 +94,7 @@ object AudioModelClientWithModels {
 
 class AudioModelClientWithModels(originalModel: AudioModel, val audioModelClient: AudioModelClient) extends DecoratorAudioModelClient {
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -104,7 +104,7 @@ class AudioModelClientWithModels(originalModel: AudioModel, val audioModelClient
     }
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -114,7 +114,7 @@ class AudioModelClientWithModels(originalModel: AudioModel, val audioModelClient
     }
   }
 
-  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -133,7 +133,7 @@ object ImageModelClientWithModels {
 
 class ImageModelClientWithModels(originalModel: ImageModel, val imageModelClient: ImageModelClient) extends DecoratorImageModelClient {
 
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -143,7 +143,7 @@ class ImageModelClientWithModels(originalModel: ImageModel, val imageModelClient
     }
   }
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -161,7 +161,7 @@ object ModerationModelClientWithModels {
 }
 
 class ModerationModelClientWithModels(originalModel: ModerationModel, val moderationModelClient: ModerationModelClient) extends DecoratorModerationModelClient {
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
    val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {
@@ -179,7 +179,7 @@ object VideoModelClientWithModels {
 }
 
 class VideoModelClientWithModels(originalModel: VideoModel, val videoModelClient: VideoModelClient) extends DecoratorVideoModelClient {
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     val apikeyModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.ApiKeyKey))
     val userModels = ModelSettings.fromEntity(attrs.get(otoroshi.plugins.Keys.UserKey))
     opts.model match {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/router.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/router.scala
@@ -1,13 +1,13 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatCallKind, ChatClient, ChatMessage, ChatPrompt, ChatResponse, ChatResponseChunk, KindBasedChatClient}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -73,7 +73,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
   override def isCohere: Boolean = false
   override def isAnthropic: Boolean = false
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     Right(List("code-router", "auto-router", "fusion-router")).vfuture
   }
 
@@ -81,7 +81,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     p.options.select("model").asOptString.getOrElse("--")
 
   // blended price = 1 x input + 3 x output per token (generations are output-heavy)
-  private def candidateCost(p: AiProvider, model: String)(implicit env: Env): Option[BigDecimal] = {
+  private def candidateCost(p: AiProvider, model: String)(using env: Env): Option[BigDecimal] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val litellmProvider = ext.costsTracking.getProvider(p.provider)
     litellmProvider.flatMap(lp => ext.costsTracking.getModel(lp, model))
@@ -90,7 +90,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
   }
 
   // resolve a refs list (Seq[String] of ids, or Seq[{ref}]) into candidates, skipping self-references
-  private def resolveCandidates(refsKey: String, refKey: String)(implicit env: Env): Seq[RouterCandidate] = {
+  private def resolveCandidates(refsKey: String, refKey: String)(using env: Env): Seq[RouterCandidate] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val refs: Seq[String] = provider.options.select(refsKey).asOpt[Seq[String]]
       .orElse(provider.options.select(refsKey).asOpt[Seq[JsObject]].map(_.map(_.select(refKey).asString)))
@@ -107,7 +107,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
   //  code-router : cheapest candidate above a quality floor, then cascade by quality/cost
   ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private def codeOrderedCandidates(originalBody: JsValue)(implicit env: Env): Seq[AiProvider] = {
+  private def codeOrderedCandidates(originalBody: JsValue)(using env: Env): Seq[AiProvider] = {
     val resolved = resolveCandidates("code_router_refs", "code_router_ref")
     if (resolved.isEmpty) {
       Seq.empty
@@ -146,7 +146,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     cands.sortBy(c => -desirability(c))
   }
 
-  private def judgeClient(cands: Seq[RouterCandidate])(implicit env: Env): Option[ChatClient] = {
+  private def judgeClient(cands: Seq[RouterCandidate])(using env: Env): Option[ChatClient] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     provider.options.select("auto_router_classifier_ref").asOptString
       .flatMap(r => ext.states.provider(r)).filterNot(_.id == provider.id).flatMap(_.getChatClient())
@@ -178,7 +178,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     }
   }
 
-  private def pickWithJudge(prompt: ChatPrompt, cands: Seq[RouterCandidate], tradeoff: Double)(implicit ec: ExecutionContext, env: Env): Future[Option[RouterCandidate]] = {
+  private def pickWithJudge(prompt: ChatPrompt, cands: Seq[RouterCandidate], tradeoff: Double)(using ec: ExecutionContext, env: Env): Future[Option[RouterCandidate]] = {
     judgeClient(cands) match {
       case None => Future.successful(None)
       case Some(jclient) =>
@@ -207,7 +207,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     }
   }
 
-  private def autoOrderedCandidates(prompt: ChatPrompt, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Seq[AiProvider]] = {
+  private def autoOrderedCandidates(prompt: ChatPrompt, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Seq[AiProvider]] = {
     val allCands = resolveCandidates("auto_router_refs", "auto_router_ref")
     // optional allowed_models filter (wildcard patterns), from the request body or the provider config
     val allowed = originalBody.select("allowed_models").asOpt[Seq[String]]
@@ -240,7 +240,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     prompt.messages.map(m => s"${m.role}: ${m.wholeTextContent}").mkString("\n").take(8000)
 
   // a configured aux provider (judge or synthesizer), falling back to the highest-quality panel member
-  private def fusionAuxClient(refKey: String, panel: Seq[RouterCandidate])(implicit env: Env): Option[ChatClient] = {
+  private def fusionAuxClient(refKey: String, panel: Seq[RouterCandidate])(using env: Env): Option[ChatClient] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     provider.options.select(refKey).asOptString
       .flatMap(r => ext.states.provider(r)).filterNot(_.id == provider.id).flatMap(_.getChatClient())
@@ -249,7 +249,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
 
   // run the whole fusion pipeline up to (but excluding) the final synthesis call, returning the
   // synthesizer client + the synthesis prompt + the body to call it with.
-  private def prepareFusion(prompt: ChatPrompt, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (ChatClient, ChatPrompt, JsObject)]] = {
+  private def prepareFusion(prompt: ChatPrompt, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (ChatClient, ChatPrompt, JsObject)]] = {
     val panel = resolveCandidates("fusion_router_refs", "fusion_router_ref").take(8)
     if (panel.isEmpty) {
       Json.obj("error" -> "no panel provider configured for the otoroshi fusion-router (set options.fusion_router_refs)").leftf
@@ -308,14 +308,14 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     }
   }
 
-  private def fusionCall(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def fusionCall(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     prepareFusion(prompt, originalBody).flatMap {
       case Left(err) => err.leftf
       case Right((client, synthPrompt, body)) => client.call(synthPrompt, attrs, body)
     }
   }
 
-  private def fusionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def fusionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     prepareFusion(prompt, originalBody).flatMap {
       case Left(err) => err.leftf
       case Right((client, synthPrompt, body)) => client.stream(synthPrompt, attrs, body)
@@ -329,7 +329,7 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
   private def isFusion(originalBody: JsValue): Boolean =
     originalBody.select("model").asOptString.exists(_.toLowerCase.contains("fusion"))
 
-  private def execute[T](prompt: ChatPrompt, originalBody: JsValue)(f: (ChatClient, JsValue) => Future[Either[JsValue, T]])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
+  private def execute[T](prompt: ChatPrompt, originalBody: JsValue)(f: (ChatClient, JsValue) => Future[Either[JsValue, T]])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
     val requestedModel = originalBody.select("model").asOptString.getOrElse("code-router").toLowerCase
     val orderedF: Future[Seq[AiProvider]] =
       if (requestedModel.contains("auto")) autoOrderedCandidates(prompt, originalBody)
@@ -358,12 +358,12 @@ class OtoroshiRouterChatClient(provider: AiProvider) extends KindBasedChatClient
     }
   }
 
-  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     if (isFusion(originalBody)) fusionCall(prompt, attrs, originalBody)
     else execute(prompt, originalBody)((client, body) => client.invoke(kind, prompt, attrs, body))
   }
 
-  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (isFusion(originalBody)) fusionStream(prompt, attrs, originalBody)
     else execute(prompt, originalBody)((client, body) => client.invokeStream(kind, prompt, attrs, body))
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/semanticcache.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/semanticcache.scala
@@ -1,9 +1,9 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.LettuceRedisClientManager
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.github.benmanes.caffeine.cache.RemovalCause
 import com.github.blemale.scaffeine.Scaffeine
 import dev.langchain4j.data.segment.TextSegment
@@ -12,16 +12,17 @@ import io.lettuce.core.output.{IntegerOutput, NestedMultiOutput, StatusOutput}
 import io.lettuce.core.protocol.{CommandArgs, ProtocolKeyword}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json.{JsValue, Json, JsObject}
+import play.api.libs.json.{JsValue, Json}
 
 import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
+import io.lettuce.core.SetArgs
 
 // ---------------------------------------------------------------------------
 //  Entry point — picks the right implementation based on redis_url
@@ -46,11 +47,11 @@ object ChatClientWithSemanticCache {
    * If embeddingRef is set and points to a valid EmbeddingModel entity, use it.
    * Otherwise, fall back to the local AllMiniLmL6V2 model.
    */
-  def embedText(text: String, embeddingRef: Option[String])(implicit ec: ExecutionContext, env: Env): Future[Array[Float]] = {
+  def embedText(text: String, embeddingRef: Option[String])(using ec: ExecutionContext, env: Env): Future[Array[Float]] = {
     embeddingRef.flatMap { ref =>
       env.adminExtensions.extension[AiExtension]
         .flatMap(_.states.embeddingModel(ref))
-        .flatMap(_.getEmbeddingModelClient()(env))
+        .flatMap(_.getEmbeddingModelClient()(using env))
     } match {
       case Some(client) =>
         client.embed(
@@ -76,27 +77,27 @@ object ChatClientWithSemanticCacheMemory {
   lazy val embeddingStores = new TrieMap[String, dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore[TextSegment]]()
   lazy val cache = Scaffeine()
     .expireAfter[String, (FiniteDuration, ChatResponse, Long)](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
     .maximumSize(5000)
     .build[String, (FiniteDuration, ChatResponse, Long)]()
   lazy val stream_cache = Scaffeine()
     .expireAfter[String, (FiniteDuration, Seq[ChatResponseChunk], Long)](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
     .maximumSize(5000)
     .build[String, (FiniteDuration, Seq[ChatResponseChunk], Long)]()
   lazy val cacheEmbeddingCleanup = Scaffeine()
     .expireAfter[String, (FiniteDuration, Function[String, Unit])](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
-    .removalListener((key: String, value: (FiniteDuration, Function[String, Unit]), reason: RemovalCause) => {
+    .removalListener((key: String, value: (FiniteDuration, Function[String, Unit]), _: RemovalCause) => {
       value._2(key)
     })
     .maximumSize(5000)
@@ -112,7 +113,7 @@ class ChatClientWithSemanticCacheMemory(originalProvider: AiProvider, val chatCl
     new dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore[TextSegment]()
   }
 
-  private def notInCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def notInCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val embeddingStore = getStore
     val r = chatClient.invoke(kind, originalPrompt, attrs, originalBody)
     r.flatMap {
@@ -134,7 +135,7 @@ class ChatClientWithSemanticCacheMemory(originalProvider: AiProvider, val chatCl
     }
   }
 
-  private def notInCacheStream(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def notInCacheStream(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val embeddingStore = getStore
     val r = chatClient.invokeStream(kind, originalPrompt, attrs, originalBody)
     r.map {
@@ -158,7 +159,7 @@ class ChatClientWithSemanticCacheMemory(originalProvider: AiProvider, val chatCl
     }
   }
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val query = originalPrompt.messages.filter(_.role.toLowerCase().trim == "user").map(_.content).mkString(", ")
     val key = CacheKeys.forQuery(kind, query)
     ChatClientWithSemanticCacheMemory.cache.getIfPresent(key) match {
@@ -190,7 +191,7 @@ class ChatClientWithSemanticCacheMemory(originalProvider: AiProvider, val chatCl
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val query = originalPrompt.messages.filter(_.role.toLowerCase().trim == "user").map(_.content).mkString(", ")
     val key = CacheKeys.forQuery(kind, query)
     ChatClientWithSemanticCacheMemory.stream_cache.getIfPresent(key) match {
@@ -226,10 +227,10 @@ object ChatClientWithSemanticCacheRedis {
   private val verifiedIndices = new TrieMap[String, Int]()
   def resetVerifiedIndex(indexName: String): Unit = verifiedIndices.remove(indexName)
 
-  private def cmd(name: String): ProtocolKeyword = new ProtocolKeyword {
-    private val bytes = name.getBytes(StandardCharsets.US_ASCII)
+  private def cmd(cmdName: String): ProtocolKeyword = new ProtocolKeyword {
+    private val bytes = cmdName.getBytes(StandardCharsets.US_ASCII)
     override def getBytes: Array[Byte] = bytes
-    override def name(): String = name
+    override def name(): String = cmdName
   }
 
   val FT_CREATE: ProtocolKeyword = cmd("FT.CREATE")
@@ -239,7 +240,7 @@ object ChatClientWithSemanticCacheRedis {
 
 class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatClient: ChatClient, redisUrl: String) extends DecoratorChatClient {
 
-  import ChatClientWithSemanticCacheRedis._
+  import ChatClientWithSemanticCacheRedis.*
 
   private val ttl = originalProvider.cache.ttl
   private val minScore = originalProvider.cache.score
@@ -271,7 +272,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
 
   // --- index lifecycle ---
 
-  private def ensureIndex(dims: Int)(implicit ec: ExecutionContext): Future[Unit] = {
+  private def ensureIndex(dims: Int)(using ec: ExecutionContext): Future[Unit] = {
     if (verifiedIndices.contains(indexName)) {
       Future.successful(())
     } else {
@@ -299,7 +300,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
 
   // --- embedding store operations ---
 
-  private def storeEmbedding(key: String, query: String, vectorBytes: Array[Byte])(implicit ec: ExecutionContext): Future[Unit] = {
+  private def storeEmbedding(key: String, query: String, vectorBytes: Array[Byte])(using ec: ExecutionContext): Future[Unit] = {
     val hashKey = s"$embKeyPrefix$key"
     val args = new CommandArgs[String, String](StringCodec.UTF8)
       .addKey(hashKey)
@@ -314,7 +315,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
       .map(_ => ())
   }
 
-  private def searchSimilar(vectorBytes: Array[Byte])(implicit ec: ExecutionContext): Future[Option[(String, Double)]] = {
+  private def searchSimilar(vectorBytes: Array[Byte])(using ec: ExecutionContext): Future[Option[(String, Double)]] = {
     val query = s"*=>[KNN 1 @embedding $$vec AS vector_score]"
     val args = new CommandArgs[String, String](StringCodec.UTF8)
       .add(indexName)
@@ -333,7 +334,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
         } else {
           // [totalCount, key1, [field, value, ...]]
           val fields = list(2) match {
-            case l: java.util.List[_] => l.asScala.map(_.toString).toList
+            case l: java.util.List[?] => l.asScala.map(_.toString).toList
             case _ => List.empty[String]
           }
           val fieldMap = fields.grouped(2).collect { case List(k, v) => k -> v }.toMap
@@ -348,7 +349,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
 
   // --- response cache operations ---
 
-  private def redisGetResponse(key: String)(implicit ec: ExecutionContext): Future[Option[(ChatResponse, Long)]] = {
+  private def redisGetResponse(key: String)(using ec: ExecutionContext): Future[Option[(ChatResponse, Long)]] = {
     toFuture(conn.async().get(s"sem-cache:call:$key"))
       .map {
         case null => None
@@ -357,12 +358,12 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
       .recover { case _ => None }
   }
 
-  private def redisPutResponse(key: String, resp: ChatResponse)(implicit ec: ExecutionContext): Unit = {
+  private def redisPutResponse(key: String, resp: ChatResponse)(using ec: ExecutionContext): Unit = {
     val json = SimpleCacheSerialization.serializeResponse(resp, System.currentTimeMillis())
-    toFuture(conn.async().psetex(s"sem-cache:call:$key", ttl.toMillis, json))
+    toFuture(conn.async().set(s"sem-cache:call:$key", json, SetArgs.Builder.px(ttl.toMillis)))
   }
 
-  private def redisGetChunks(key: String)(implicit ec: ExecutionContext): Future[Option[(Seq[ChatResponseChunk], Long)]] = {
+  private def redisGetChunks(key: String)(using ec: ExecutionContext): Future[Option[(Seq[ChatResponseChunk], Long)]] = {
     toFuture(conn.async().get(s"sem-cache:stream:$key"))
       .map {
         case null => None
@@ -371,14 +372,14 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
       .recover { case _ => None }
   }
 
-  private def redisPutChunks(key: String, chunks: Seq[ChatResponseChunk])(implicit ec: ExecutionContext): Unit = {
+  private def redisPutChunks(key: String, chunks: Seq[ChatResponseChunk])(using ec: ExecutionContext): Unit = {
     val json = SimpleCacheSerialization.serializeChunks(chunks, System.currentTimeMillis())
-    toFuture(conn.async().psetex(s"sem-cache:stream:$key", ttl.toMillis, json))
+    toFuture(conn.async().set(s"sem-cache:stream:$key", json, SetArgs.Builder.px(ttl.toMillis)))
   }
 
   // --- cache miss handlers ---
 
-  private def notInCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def notInCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val r = chatClient.invoke(kind, originalPrompt, attrs, originalBody)
     r.flatMap {
       case Left(err) => err.leftf
@@ -402,7 +403,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
     }
   }
 
-  private def notInCacheStream(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def notInCacheStream(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val r = chatClient.invokeStream(kind, originalPrompt, attrs, originalBody)
     r.map {
       case Left(err) => err.left
@@ -424,7 +425,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
 
   // --- main logic ---
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val query = originalPrompt.messages.filter(_.role.toLowerCase().trim == "user").map(_.content).mkString(", ")
     val key = CacheKeys.forQuery(kind, query)
     // 1. exact key lookup
@@ -456,7 +457,7 @@ class ChatClientWithSemanticCacheRedis(originalProvider: AiProvider, val chatCli
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val query = originalPrompt.messages.filter(_.role.toLowerCase().trim == "user").map(_.content).mkString(", ")
     val key = CacheKeys.forQuery(kind, query)
     // 1. exact key lookup

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/simplecache.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/decorators/simplecache.scala
@@ -1,17 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.decorators
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.LettuceRedisClientManager
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.github.blemale.scaffeine.Scaffeine
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import io.lettuce.core.SetArgs
 
 // ---------------------------------------------------------------------------
 //  Entry point — picks the right implementation based on redis_url
@@ -145,18 +146,18 @@ object ChatClientWithSimpleCacheMemory {
 
   val cache = Scaffeine()
     .expireAfter[String, (FiniteDuration, ChatResponse, Long)](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
     .maximumSize(5000)
     .build[String, (FiniteDuration, ChatResponse, Long)]()
 
   val stream_cache = Scaffeine()
     .expireAfter[String, (FiniteDuration, Seq[ChatResponseChunk], Long)](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
     .maximumSize(5000)
     .build[String, (FiniteDuration, Seq[ChatResponseChunk], Long)]()
@@ -166,7 +167,7 @@ class ChatClientWithSimpleCacheMemory(originalProvider: AiProvider, val chatClie
 
   private val ttl = originalProvider.cache.ttl
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     // the endpoint is part of the key: a /responses answer is not interchangeable with a chat one
     val key = CacheKeys.forPrompt(kind, originalPrompt)
     ChatClientWithSimpleCacheMemory.cache.getIfPresent(key) match {
@@ -188,7 +189,7 @@ class ChatClientWithSimpleCacheMemory(originalProvider: AiProvider, val chatClie
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val key = CacheKeys.forPrompt(kind, originalPrompt)
     ChatClientWithSimpleCacheMemory.stream_cache.getIfPresent(key) match {
       case Some((_, response, _)) => Source(response.toList).rightf
@@ -226,17 +227,17 @@ class ChatClientWithSimpleCacheRedis(originalProvider: AiProvider, val chatClien
     promise.future
   }
 
-  private def redisGet(key: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
+  private def redisGet(key: String)(using ec: ExecutionContext): Future[Option[String]] = {
     toFuture(LettuceRedisClientManager.getConnection(redisUrl).async().get(key))
       .map(Option(_))
       .recover { case _ => None }
   }
 
-  private def redisPut(key: String, value: String)(implicit ec: ExecutionContext): Unit = {
-    toFuture(LettuceRedisClientManager.getConnection(redisUrl).async().psetex(key, ttl.toMillis, value))
+  private def redisPut(key: String, value: String)(using ec: ExecutionContext): Unit = {
+    toFuture(LettuceRedisClientManager.getConnection(redisUrl).async().set(key, value, SetArgs.Builder.px(ttl.toMillis)))
   }
 
-  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def invoke(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val key = CacheKeys.forPrompt(kind, originalPrompt)
     redisGet(s"simple-cache:call:$key").flatMap {
       case Some(value) =>
@@ -253,7 +254,7 @@ class ChatClientWithSimpleCacheRedis(originalProvider: AiProvider, val chatClien
     }
   }
 
-  private def callAndCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  private def callAndCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     chatClient.invoke(kind, originalPrompt, attrs, originalBody).map {
       case Left(err) => err.left
       case Right(resp) =>
@@ -264,7 +265,7 @@ class ChatClientWithSimpleCacheRedis(originalProvider: AiProvider, val chatClien
     }
   }
 
-  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def invokeStream(kind: ChatCallKind, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val key = CacheKeys.forPrompt(kind, originalPrompt)
     redisGet(s"simple-cache:stream:$key").flatMap {
       case Some(value) =>
@@ -276,7 +277,7 @@ class ChatClientWithSimpleCacheRedis(originalProvider: AiProvider, val chatClien
     }
   }
 
-  private def streamAndCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  private def streamAndCache(kind: ChatCallKind, key: String, originalPrompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     chatClient.invokeStream(kind, originalPrompt, attrs, originalBody).map {
       case Left(err) => err.left
       case Right(resp) =>

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/a2a.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/a2a.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
-import akka.stream.scaladsl.{Sink, Source}
-import com.cloud.apim.otoroshi.extensions.aigateway.a2a._
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import com.cloud.apim.otoroshi.extensions.aigateway.a2a.*
 import otoroshi.api.{GenericResourceAccessApiWithState, Resource, ResourceVersion}
 import otoroshi.env.Env
 import otoroshi.models.{EntityLocation, EntityLocationSupport}
@@ -10,13 +10,13 @@ import otoroshi.next.models.NgTlsConfig
 import otoroshi.security.IdGenerator
 import otoroshi.storage.{BasicStore, RedisLike, RedisLikeStore}
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiExtension, AiGatewayExtensionDatastores, AiGatewayExtensionState}
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedKey
 
 import java.util.Base64
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -201,7 +201,7 @@ object A2AServer {
         extractIdf = c => datastores.a2aServersDatastore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           A2AServer(
             id = IdGenerator.namedId("a2a-server", env),
             enabled = true,
@@ -243,7 +243,7 @@ class KvA2AServersDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, 
   extends A2AServersDataStore
     with RedisLikeStore[A2AServer] {
   override def fmt: Format[A2AServer] = A2AServer.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:a2asrv:$id"
   override def extractId(value: A2AServer): String = value.id
 }
@@ -338,7 +338,7 @@ case class A2AConnector(
     }
 
   // resolve outgoing auth headers; oauth2_client_credentials fetches (and caches) a token asynchronously
-  def resolveHeaders()(implicit ec: ExecutionContext, env: Env): Future[Seq[(String, String)]] = {
+  def resolveHeaders()(using ec: ExecutionContext, env: Env): Future[Seq[(String, String)]] = {
     authentication.kind.toLowerCase match {
       case "oauth2_client_credentials" =>
         (authentication.tokenUrl, authentication.clientId, authentication.clientSecret) match {
@@ -354,7 +354,7 @@ case class A2AConnector(
   }
 
   // resolve the Agent Card (cached) and apply the skills_filter
-  def listSkills(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[AgentSkill]] = {
+  def listSkills(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[AgentSkill]] = {
     resolveHeaders().flatMap { headers =>
       A2AClient.fetchAgentCard(id, url, agentCardPath, agentCardFallbackPath, headers, tls, timeoutDuration).map {
         case Left(_) => Seq.empty
@@ -365,12 +365,12 @@ case class A2AConnector(
     }
   }
 
-  def listSkillsBlocking(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Seq[AgentSkill] = {
+  def listSkillsBlocking(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Seq[AgentSkill] = {
     Try(Await.result(listSkills(attrs), timeoutDuration + 5.seconds)).getOrElse(Seq.empty)
   }
 
   // execute a skill: extract the `message` argument, send an A2A (streaming) SendMessage to the remote agent, return text
-  def call(skillId: String, args: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  def call(skillId: String, args: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
     val message: String = Try(Json.parse(args)).toOption.flatMap(_.select("message").asOpt[String]).getOrElse(args)
     resolveHeaders().flatMap { headers =>
       A2AClient.fetchAgentCard(id, url, agentCardPath, agentCardFallbackPath, headers, tls, timeoutDuration).flatMap {
@@ -426,7 +426,7 @@ object A2AConnector {
         agentCardFallbackPath = json.select("agent_card_fallback_path").asOpt[String].getOrElse(A2A.legacyWellKnownPath),
         a2aVersion = json.select("a2a_version").asOpt[String],
         authentication = json.select("authentication").asOpt[JsValue].map(A2AConnectorAuth.from).getOrElse(A2AConnectorAuth()),
-        tls = json.select("tls").asOpt(NgTlsConfig.format).getOrElse(NgTlsConfig()),
+        tls = json.select("tls").asOpt(using NgTlsConfig.format).getOrElse(NgTlsConfig()),
         timeout = json.select("timeout").asOpt[Long].getOrElse(30000L),
         streaming = json.select("streaming").asOpt[Boolean].getOrElse(false),
         skillsFilter = json.select("skills_filter").asOpt[Seq[String]].getOrElse(Seq.empty),
@@ -453,7 +453,7 @@ object A2AConnector {
         extractIdf = c => datastores.a2aConnectorsDatastore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           A2AConnector(
             id = IdGenerator.namedId("a2a-connector", env),
             enabled = true,
@@ -485,7 +485,7 @@ class KvA2AConnectorsDataStore(extensionId: AdminExtensionId, redisCli: RedisLik
   extends A2AConnectorsDataStore
     with RedisLikeStore[A2AConnector] {
   override def fmt: Format[A2AConnector] = A2AConnector.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:a2aconntr:$id"
   override def extractId(value: A2AConnector): String = value.id
 }
@@ -511,7 +511,7 @@ object A2ASupport {
   )
 
   // the connector list comes from attrs (set by the provider before tool build/dispatch) — keeps build & dispatch in sync
-  private def connectorsWithSkills(attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Seq[(A2AConnector, Int, AgentSkill)] = {
+  private def connectorsWithSkills(attrs: TypedMap)(using env: Env, ec: ExecutionContext): Seq[(A2AConnector, Int, AgentSkill)] = {
     val connectors = attrs.get(A2AConnectorsKey).getOrElse(Seq.empty)
     val ext = env.adminExtensions.extension[AiExtension].get
     connectors.zipWithIndex.flatMap { case (cid, idx) => ext.states.a2aConnector(cid).filter(_.enabled).map(c => (c, idx)) }.flatMap {
@@ -519,7 +519,7 @@ object A2ASupport {
     }
   }
 
-  def tools(attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Seq[JsObject] = {
+  def tools(attrs: TypedMap)(using env: Env, ec: ExecutionContext): Seq[JsObject] = {
     connectorsWithSkills(attrs).map { case (connector, idx, skill) =>
       Json.obj("type" -> "function", "function" -> Json.obj(
         "name" -> s"a2a___${idx}___${skill.id}",
@@ -530,7 +530,7 @@ object A2ASupport {
     }
   }
 
-  def toolsAnthropic(attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Seq[JsObject] = {
+  def toolsAnthropic(attrs: TypedMap)(using env: Env, ec: ExecutionContext): Seq[JsObject] = {
     connectorsWithSkills(attrs).map { case (connector, idx, skill) =>
       Json.obj(
         "name" -> s"a2a___${idx}___${skill.id}",
@@ -540,7 +540,7 @@ object A2ASupport {
     }
   }
 
-  def toolsCohere(attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): (Seq[JsObject], Map[String, String]) = {
+  def toolsCohere(attrs: TypedMap)(using env: Env, ec: ExecutionContext): (Seq[JsObject], Map[String, String]) = {
     val map = scala.collection.mutable.Map.empty[String, String]
     val tools = connectorsWithSkills(attrs).map { case (connector, idx, skill) =>
       val key = s"${idx}___${skill.id}".sha256
@@ -555,7 +555,7 @@ object A2ASupport {
     (tools, map.toMap)
   }
 
-  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callTool(functions, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool", "content" -> resp, "tool_call_id" -> tc.id
@@ -563,7 +563,7 @@ object A2ASupport {
     }
   }
 
-  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callTool(functions, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "content" -> "", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool", "content" -> resp
@@ -571,7 +571,7 @@ object A2ASupport {
     }
   }
 
-  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val connectors = attrs.get(A2AConnectorsKey).getOrElse(Seq.empty)
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
@@ -583,10 +583,10 @@ object A2ASupport {
           Json.obj("role" -> "user", "content" -> Json.arr(Json.obj("type" -> "tool_result", "tool_use_id" -> tc.id, "content" -> resp)))
         ))
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val connectors = attrs.get(A2AConnectorsKey).getOrElse(Seq.empty)
     Source(functions.toList)
       .mapAsync(1) { _toolCall =>
@@ -602,20 +602,20 @@ object A2ASupport {
           "role" -> "tool", "content" -> resp, "tool_call_id" -> tc.id
         )))
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def callTool(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callTool(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val connectors = attrs.get(A2AConnectorsKey).getOrElse(Seq.empty)
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         execute(connectors, toolCall.function.a2aConnectorId, toolCall.function.a2aFunctionName, toolCall.function.arguments, attrs).map(r => (r, toolCall))
       }
       .flatMapConcat { case (resp, tc) => f(resp, tc) }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def execute(connectors: Seq[String], idx: Int, skillId: String, args: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  private def execute(connectors: Seq[String], idx: Int, skillId: String, args: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
     if (idx < 0 || idx >= connectors.size) {
       s"error: unknown a2a connector index ${idx}".vfuture
     } else {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/aiproviderscatalog.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/aiproviderscatalog.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.OpenAiLikeProviders
-import play.api.libs.json._
+import play.api.libs.json.*
 
 /**
  * Catalog of every provider type Otoroshi LLM can talk to, together with the modalities

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/audio.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/audio.scala
@@ -2,16 +2,16 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.AudioModelClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.AudioModelClientDecorators
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -42,7 +42,7 @@ case class AudioModel(
 
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
 
-  def getAudioModelClient()(implicit env: Env): Option[AudioModelClient] = {
+  def getAudioModelClient()(using env: Env): Option[AudioModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
     val _token = connection.select("token").asOpt[String].getOrElse("xxx")
@@ -72,7 +72,7 @@ object AudioModel {
   // `supportedProviders` (and the providers catalog) is derived from these keys.
   val clientBuilders: Map[String, AudioModel.ClientContext => Option[AudioModelClient]] = Map(
     "openai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "OpenAI", env = env)
       val ttsopts = OpenAIAudioModelClientTtsOptions.fromJson(ttsOptions)
       val sttopts = OpenAIAudioModelClientSttOptions.fromJson(sttOptions)
@@ -80,7 +80,7 @@ object AudioModel {
       new OpenAIAudioModelClient(api, ttsopts, sttopts, transopts, id).some
     },
     "azure-openai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val resourceName = connection.select("resource_name").as[String]
       val deploymentId = connection.select("deployment_id").as[String]
       val version = connection.select("api_version").asOpt[String].getOrElse("v1")
@@ -98,7 +98,7 @@ object AudioModel {
       }
     },
     "cloud-temple" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Cloud Temple", env = env)
       val ttsopts = OpenAIAudioModelClientTtsOptions.fromJson(ttsOptions)
       val sttopts = OpenAIAudioModelClientSttOptions.fromJson(sttOptions)
@@ -106,7 +106,7 @@ object AudioModel {
       new OpenAIAudioModelClient(api, ttsopts, sttopts, transopts, id).some
     },
     "groq" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new GroqApi(baseUrl.getOrElse(GroqApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val ttsopts = GroqAudioModelClientTtsOptions.fromJson(ttsOptions)
       val sttopts = GroqAudioModelClientSttOptions.fromJson(sttOptions)
@@ -114,33 +114,33 @@ object AudioModel {
       new GroqAudioModelClient(api, ttsopts, sttopts, transopts, id).some
     },
     "elevenlabs" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new ElevenLabsApi(baseUrl.getOrElse(ElevenLabsApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val ttsopts = ElevenLabsAudioModelClientTtsOptions.fromJson(ttsOptions)
       val sttopts = ElevenLabsAudioModelClientSttOptions.fromJson(sttOptions)
       new ElevenLabsAudioModelClient(api, ttsopts, sttopts, id).some
     },
     "mistral" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new MistralAiApi(baseUrl.getOrElse(MistralAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val sttopts = MistralAiAudioModelClientSttOptions.fromJson(sttOptions)
       new MistralAIAudioModelClient(api, sttopts, id).some
     },
     "alphaedge" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new AlphaEdgeApi(baseUrl.getOrElse(AlphaEdgeApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val sttopts = AlphaEdgeAudioModelClientSttOptions.fromJson(sttOptions)
       new AlphaEdgeAudioModelClient(api, sttopts, id).some
     },
     "openrouter" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenRouterApi(baseUrl.getOrElse(OpenRouterApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val ttsopts = OpenRouterAudioModelClientTtsOptions.fromJson(ttsOptions)
       val sttopts = OpenRouterAudioModelClientSttOptions.fromJson(sttOptions)
       new OpenRouterAudioModelClient(api, ttsopts, sttopts, id).some
     },
     "openai-compatible" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // generic OpenAI-compatible audio endpoint: base url, display name, headers and param
       // mappings are all driven by the connection config (dynamic name). TTS/STT/Translation are
       // enabled according to the configured options.
@@ -166,7 +166,7 @@ object AudioModel {
       new OpenAIAudioModelClient(api, ttsopts, sttopts, transopts, id).some
     },
     "ovh-ai-endpoints" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // OVH AI Endpoints audio: transcription (speech-to-text) only, through their unified
       // OpenAI-compatible API. TTS and translation are forced off.
       val api = new OpenAiApi(baseUrl.getOrElse(OVHAiEndpointsApi.unifiedUrl), token, timeout.getOrElse(3.minutes), providerName = "OVH", env = env)
@@ -223,7 +223,7 @@ object AudioModel {
         extractIdf = c => datastores.AudioModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("openai") => AudioModel(
               id = IdGenerator.namedId("audio-model", env),
@@ -283,7 +283,7 @@ class KvAudioModelsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike,
     with RedisLikeStore[AudioModel] {
   override def fmt: Format[AudioModel] = AudioModel.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:audiomodels:$id"
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/budget.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/budget.scala
@@ -1,31 +1,33 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
-import akka.actor.Cancellable
-import akka.http.scaladsl.util.FastFuture
+import org.apache.pekko.actor.Cancellable
+import org.apache.pekko.http.scaladsl.util.FastFuture
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.ChatClientWithAuding
 import org.joda.time.DateTime
-import otoroshi.api._
+import otoroshi.api.*
 import otoroshi.cluster.Cluster
 import otoroshi.env.Env
 import otoroshi.events.AlertEvent
 import otoroshi.gateway.Retry
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.next.utils.JsonHelpers
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi.utils.{JsonPathValidator, RegexPool, TypedMap}
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSAuthScheme
+import play.api.libs.ws.WSBodyWritables.given
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic._
+import java.util.concurrent.atomic.*
 import scala.collection.concurrent.TrieMap
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
+import org.apache.pekko.actor.Scheduler
 
 object AiBudgetClusterAgent {
   val totalUsdCounters = new TrieMap[String, DoubleAdder]()
@@ -57,8 +59,7 @@ object AiBudgetClusterAgent {
 
   def start(env: Env, ext: AiExtension): Unit = {
     if (env.clusterConfig.mode.isWorker) {
-      implicit val ev = env
-      implicit val ec = env.otoroshiExecutionContext
+      given ec: ExecutionContext = env.otoroshiExecutionContext
       schedulerRef.set(env.otoroshiScheduler.scheduleAtFixedRate(10.seconds, env.clusterConfig.worker.state.pollEvery.millis) { () =>
         sendDeltas(env, ext)
       })
@@ -95,30 +96,28 @@ object AiBudgetClusterAgent {
   }
 
   private def sendDeltas(env: Env, ext: AiExtension): Unit = {
-    import otoroshi.utils.http.Implicits._
-    implicit val ev = env
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val sc = env.otoroshiScheduler
-    implicit val mat = env.otoroshiMaterializer
+    import otoroshi.utils.http.Implicits.*
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given sc: Scheduler = env.otoroshiScheduler
     if (env.clusterConfig.mode.isWorker) {
       val config = env.clusterConfig
       val payload = Json.obj(
-        "total_usd" -> JsObject(totalUsdCounters.toMap.mapValues(_.sum.json)),
-        "total_tokens" -> JsObject(totalTokensCounters.toMap.mapValues(_.get.json)),
-        "inference_usd" -> JsObject(inferenceUsdCounters.toMap.mapValues(_.sum.json)),
-        "inference_tokens" -> JsObject(inferenceTokensCounters.toMap.mapValues(_.get.json)),
-        "image_usd" -> JsObject(imageUsdCounters.toMap.mapValues(_.sum.json)),
-        "image_tokens" -> JsObject(imageTokensCounters.toMap.mapValues(_.get.json)),
-        "audio_usd" -> JsObject(audioUsdCounters.toMap.mapValues(_.sum.json)),
-        "audio_tokens" -> JsObject(audioTokensCounters.toMap.mapValues(_.get.json)),
-        "video_usd" -> JsObject(videoUsdCounters.toMap.mapValues(_.sum.json)),
-        "video_tokens" -> JsObject(videoTokensCounters.toMap.mapValues(_.get.json)),
-        "embedding_usd" -> JsObject(embeddingUsdCounters.toMap.mapValues(_.sum.json)),
-        "embedding_tokens" -> JsObject(embeddingTokensCounters.toMap.mapValues(_.get.json)),
-        "moderation_usd" -> JsObject(moderationUsdCounters.toMap.mapValues(_.sum.json)),
-        "moderation_tokens" -> JsObject(moderationTokensCounters.toMap.mapValues(_.get.json)),
-        "ocr_usd" -> JsObject(ocrUsdCounters.toMap.mapValues(_.sum.json)),
-        "ocr_pages" -> JsObject(ocrPagesCounters.toMap.mapValues(_.get.json)),
+        "total_usd" -> JsObject(totalUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "total_tokens" -> JsObject(totalTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "inference_usd" -> JsObject(inferenceUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "inference_tokens" -> JsObject(inferenceTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "image_usd" -> JsObject(imageUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "image_tokens" -> JsObject(imageTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "audio_usd" -> JsObject(audioUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "audio_tokens" -> JsObject(audioTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "video_usd" -> JsObject(videoUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "video_tokens" -> JsObject(videoTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "embedding_usd" -> JsObject(embeddingUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "embedding_tokens" -> JsObject(embeddingTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "moderation_usd" -> JsObject(moderationUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "moderation_tokens" -> JsObject(moderationTokensCounters.toMap.view.mapValues(_.get.json).toMap),
+        "ocr_usd" -> JsObject(ocrUsdCounters.toMap.view.mapValues(_.sum.json).toMap),
+        "ocr_pages" -> JsObject(ocrPagesCounters.toMap.view.mapValues(_.get.json).toMap),
       )
       Retry
         .retry(
@@ -126,7 +125,7 @@ object AiBudgetClusterAgent {
           delay = config.retryDelay,
           factor = config.retryFactor,
           ctx = "leader-pushing-budgets-delta"
-        ) { tryCount =>
+        ) { _ =>
           if (Cluster.logger.isDebugEnabled)
             Cluster.logger.debug(s"Pushing ai budgets deltas to leaders")
           env.MtlsWs
@@ -150,7 +149,7 @@ object AiBudgetClusterAgent {
               Some(Json.parse(resp.body))
             }
         }
-        .recover { case e =>
+        .recover { case _ =>
           if (Cluster.logger.isDebugEnabled)
             Cluster.logger.debug(
               s"[${env.clusterConfig.mode.name}] Error while pushing ai budgets deltas Otoroshi leader cluster"
@@ -164,11 +163,11 @@ object AiBudgetClusterAgent {
 }
 
 sealed trait AiBudgetUsageKind {
-  def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit
+  def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit
 }
 object AiBudgetUsageKind {
   case object Inference extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrInferenceUsd(c)
@@ -180,7 +179,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Image extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrImageUsd(c)
@@ -192,7 +191,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Audio extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrAudioUsd(c)
@@ -204,7 +203,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Video extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrVideoUsd(c)
@@ -216,7 +215,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Embedding extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrEmbeddingUsd(c)
@@ -228,7 +227,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Moderation extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c => 
         budget.incrTotalUsd(c)
         budget.incrModerationUsd(c)
@@ -240,7 +239,7 @@ object AiBudgetUsageKind {
     }
   }
   case object Ocr extends AiBudgetUsageKind {
-    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Unit = {
+    def updateUsage(budget: AiBudget, cost: Option[BigDecimal], tokens: Option[Long], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Unit = {
       cost.foreach { c =>
         budget.incrTotalUsd(c)
         budget.incrOcrUsd(c)
@@ -658,231 +657,231 @@ case class AiBudget(
 
   def cycleId: String = cycle.map(_.toString).getOrElse("single")
 
-  def totalUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:total-usd"
-  def totalTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:total-tokens"
+  def totalUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:total-usd"
+  def totalTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:total-tokens"
 
-  def inferenceUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:inference-usd"
-  def inferenceTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:inference-tokens"
+  def inferenceUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:inference-usd"
+  def inferenceTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:inference-tokens"
 
-  def imageUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:image-usd"
-  def imageTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:image-tokens"
+  def imageUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:image-usd"
+  def imageTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:image-tokens"
 
-  def audioUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:audio-usd"
-  def audioTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:audio-tokens"
+  def audioUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:audio-usd"
+  def audioTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:audio-tokens"
 
-  def videoUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:video-usd"
-  def videoTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:video-tokens"
+  def videoUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:video-usd"
+  def videoTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:video-tokens"
 
-  def embeddingUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:embedding-usd"
-  def embeddingTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:embedding-tokens"
+  def embeddingUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:embedding-usd"
+  def embeddingTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:embedding-tokens"
 
-  def moderationUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:moderation-usd"
-  def moderationTokensKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:moderation-tokens"
+  def moderationUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:moderation-usd"
+  def moderationTokensKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:moderation-tokens"
 
-  def ocrUsdKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:ocr-usd"
-  def ocrPagesKey(implicit env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:ocr-pages"
+  def ocrUsdKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:ocr-usd"
+  def ocrPagesKey(using env: Env): String = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:ocr-pages"
 
-  def incrTotalUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrTotalUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.totalUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(totalUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrTotalTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrTotalTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.totalTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(totalTokensKey, by)
   }
 
-  def incrInferenceUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrInferenceUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.inferenceUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(inferenceUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrInferenceTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrInferenceTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.inferenceTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(inferenceTokensKey, by)
   }
 
-  def incrImageUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrImageUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.imageUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(imageUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrImageTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrImageTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.imageTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(imageTokensKey, by)
   }
 
-  def incrAudioUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrAudioUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.audioUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(audioUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrAudioTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrAudioTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.audioTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(audioTokensKey, by)
   }
 
-  def incrVideoUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrVideoUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.videoUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(videoUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrVideoTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrVideoTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.videoTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(videoTokensKey, by)
   }
 
-  def incrEmbeddingUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrEmbeddingUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.embeddingUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(embeddingUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrEmbeddingTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrEmbeddingTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.embeddingTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(embeddingTokensKey, by)
   }
 
-  def incrModerationUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrModerationUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.moderationUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(moderationUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrModerationTokens(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrModerationTokens(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.moderationTokensCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(moderationTokensKey, by)
   }
 
-  def incrOcrUsd(by: BigDecimal)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrOcrUsd(by: BigDecimal)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.ocrUsdCounters.getOrElseUpdate(s"$id:$cycleId", new DoubleAdder()).add(by.toDouble)
     }
     env.datastores.rawDataStore.incrby(ocrUsdKey, by.*(BigDecimal(1000000000)).toLong)
   }
 
-  def incrOcrPages(by: Long)(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def incrOcrPages(by: Long)(using ec: ExecutionContext, env: Env): Future[Long] = {
     if (env.clusterConfig.mode.isWorker) {
       AiBudgetClusterAgent.ocrPagesCounters.getOrElseUpdate(s"$id:$cycleId", new AtomicLong()).addAndGet(by)
     }
     env.datastores.rawDataStore.incrby(ocrPagesKey, by)
   }
 
-  def getTotalUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(totalUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(totalTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalInferenceUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalInferenceUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(inferenceUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalInferenceTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalInferenceTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(inferenceTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalImageUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalImageUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(imageUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalImageTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalImageTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(imageTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalAudioUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalAudioUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(audioUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalAudioTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalAudioTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(audioTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalVideoUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalVideoUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(videoUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalVideoTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalVideoTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(videoTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalEmbeddingUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalEmbeddingUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(embeddingUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalEmbeddingTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalEmbeddingTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(embeddingTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalModerationUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalModerationUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(moderationUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalModerationTokens()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalModerationTokens()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(moderationTokensKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def getTotalOcrUsd()(implicit ec: ExecutionContext, env: Env): Future[BigDecimal] = {
+  def getTotalOcrUsd()(using ec: ExecutionContext, env: Env): Future[BigDecimal] = {
     env.datastores.rawDataStore.get(ocrUsdKey).map(_.map { strValue =>
       val lngValue = strValue.utf8String.toLong
       BigDecimal(lngValue)./(BigDecimal(1000000000))
     }.getOrElse(0L))
   }
 
-  def getTotalOcrPages()(implicit ec: ExecutionContext, env: Env): Future[Long] = {
+  def getTotalOcrPages()(using ec: ExecutionContext, env: Env): Future[Long] = {
     env.datastores.rawDataStore.get(ocrPagesKey).map(_.map(_.utf8String.toLong).getOrElse(0L))
   }
 
-  def resetCurrentCycle()(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  def resetCurrentCycle()(using ec: ExecutionContext, env: Env): Future[Unit] = {
     env.datastores.rawDataStore.keys(s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:$cycleId:*").flatMap { keys =>
       env.datastores.rawDataStore.del(keys).map { _ =>
         ()
@@ -890,7 +889,7 @@ case class AiBudget(
     }
   }
 
-  def resetAll()(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  def resetAll()(using ec: ExecutionContext, env: Env): Future[Unit] = {
     env.datastores.rawDataStore.keys(s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:aibudgets-counter:$id:*").flatMap { keys =>
       env.datastores.rawDataStore.del(keys).map { _ =>
         ()
@@ -898,7 +897,7 @@ case class AiBudget(
     }
   }
 
-  def getConsumptions()(implicit ec: ExecutionContext, env: Env): Future[AiBudgetConsumptions] = {
+  def getConsumptions()(using ec: ExecutionContext, env: Env): Future[AiBudgetConsumptions] = {
     env.datastores.rawDataStore.mget(Seq(
       totalUsdKey,
       totalTokensKey,
@@ -939,7 +938,7 @@ case class AiBudget(
     }
   }
 
-  def matchesRules(ctx: JsValue)(implicit env: Env): Boolean = {
+  def matchesRules(ctx: JsValue)(using env: Env): Boolean = {
     if (scope.rules.isEmpty) {
       false
     } else {
@@ -950,7 +949,7 @@ case class AiBudget(
     }
   }
 
-  def matches(ctx: JsValue, apikey: Option[ApiKey], user: Option[PrivateAppsUser], provider: Option[Entity], model: Option[String])(implicit env: Env): Boolean = {
+  def matches(ctx: JsValue, apikey: Option[ApiKey], user: Option[PrivateAppsUser], provider: Option[Entity], model: Option[String])(using env: Env): Boolean = {
     if (!enabled) {
       false
     } else if (startAt.isAfterNow) {
@@ -982,13 +981,13 @@ case class AiBudget(
     }
   }
 
-  def isNotWithinBudget(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Boolean] = isNotWithinBudgetWithConsumption(attrs).map(r => r._1)
+  def isNotWithinBudget(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Boolean] = isNotWithinBudgetWithConsumption(attrs).map(r => r._1)
 
-  def isWithinBudget(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Boolean] = isWithinBudgetWithConsumption(attrs).map(r => r._1)
+  def isWithinBudget(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Boolean] = isWithinBudgetWithConsumption(attrs).map(r => r._1)
 
-  def isNotWithinBudgetWithConsumption(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[(Boolean, Option[AiBudgetConsumptions])] = isWithinBudgetWithConsumption(attrs).map(r => (!r._1, r._2))
+  def isNotWithinBudgetWithConsumption(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[(Boolean, Option[AiBudgetConsumptions])] = isWithinBudgetWithConsumption(attrs).map(r => (!r._1, r._2))
 
-  def isWithinBudgetWithConsumption(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[(Boolean, Option[AiBudgetConsumptions])] = {
+  def isWithinBudgetWithConsumption(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[(Boolean, Option[AiBudgetConsumptions])] = {
     val cycleValue = cycle.getOrElse(-1)
     if (cycleValue >= (renewals + 1)) {
       (false, None).vfuture
@@ -1100,7 +1099,7 @@ object AiBudget {
       val startAt = (json \ "start_at").asOpt[String].map(DateTime.parse).getOrElse(DateTime.now())
       val endAt = (json \ "end_at").asOpt[String].map(DateTime.parse).getOrElse(DateTime.now().plusDays(365))
       // val renewals = (json \ "renewals").asOpt[Int]
-      val duration = (json \ "duration").as(AiBudgetDuration.format)
+      val duration = (json \ "duration").as(using AiBudgetDuration.format)
       AiBudget(
         location = otoroshi.models.EntityLocation.readFromKey(json),
         id = (json \ "id").as[String],
@@ -1113,9 +1112,9 @@ object AiBudget {
         endAt = endAt,
         // renewals = finalRenewals.some,
         duration = duration,
-        limits = (json \ "limits").as(AiBudgetLimits.format),
-        scope = (json \ "scope").as(AiBudgetScope.format),
-        actionOnExceed = (json \ "action_on_exceed").as(AiBudgetActionOnExceed.format)
+        limits = (json \ "limits").as(using AiBudgetLimits.format),
+        scope = (json \ "scope").as(using AiBudgetScope.format),
+        actionOnExceed = (json \ "action_on_exceed").as(using AiBudgetActionOnExceed.format)
       )
     } match {
       case Failure(ex) =>
@@ -1139,7 +1138,7 @@ object AiBudget {
         extractIdf = c => datastores.budgetsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           AiBudget(
             id = IdGenerator.namedId("budget", env),
             name = "AI Budget",
@@ -1212,7 +1211,7 @@ trait AiBudgetsDataStore extends BasicStore[AiBudget] {
 }
 
 object AiBudgetsDataStore {
-  def handleWithinBudget[A](attrs: TypedMap)(notInBudget: => Future[A], inBudget: => Future[A])(implicit env: Env, ec: ExecutionContext): Future[A] = {
+  def handleWithinBudget[A](attrs: TypedMap)(notInBudget: => Future[A], inBudget: => Future[A])(using env: Env, ec: ExecutionContext): Future[A] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     if (ext.budgetsEnabled) {
       val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -1283,7 +1282,7 @@ class KvAiBudgetsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, _
 
   override def fmt: Format[AiBudget] = AiBudget.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:aibudgets:$id"
 
@@ -1293,8 +1292,8 @@ class KvAiBudgetsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, _
     val ext = _env.adminExtensions.extension[AiExtension].get
     if (ext.budgetsEnabled) {
       if (ext.states.hasBudgets && ((cost.isDefined && cost.get.>(BigDecimal(0))) || (tokens.isDefined && tokens.get > 0L))) {
-        implicit val ec = _env.analyticsExecutionContext
-        implicit val env = _env
+        given ec: ExecutionContext = _env.analyticsExecutionContext
+        given env: Env = _env
         val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
         val user = attrs.get(otoroshi.plugins.Keys.UserKey)
         val snowflake = attrs.get(otoroshi.plugins.Keys.SnowFlakeKey)
@@ -1335,7 +1334,7 @@ class KvAiBudgetsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, _
   }
 
   def findMatchingBudgets(ctx: JsValue, apikey: Option[ApiKey], user: Option[PrivateAppsUser], provider: Option[Entity], model: Option[String]): Future[Seq[AiBudget]] = {
-    implicit val env = _env
+    given env: Env = _env
     val ext = _env.adminExtensions.extension[AiExtension].get
     if (ext.budgetsEnabled) {
       if (ext.states.hasBudgets) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/context.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/context.scala
@@ -3,13 +3,13 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, InputChatMessage}
 import otoroshi.api.{GenericResourceAccessApiWithState, Resource, ResourceVersion}
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiGatewayExtensionDatastores, AiGatewayExtensionState}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.{Failure, Success, Try}
 
@@ -88,7 +88,7 @@ object PromptContext {
         extractIdf = c => datastores.promptContextDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           PromptContext(
             id = IdGenerator.namedId("prompt-context", env),
             name = "Prompt context",
@@ -119,7 +119,7 @@ class KvPromptContextDataStore(extensionId: AdminExtensionId, redisCli: RedisLik
   extends PromptContextDataStore
     with RedisLikeStore[PromptContext] {
   override def fmt: Format[PromptContext]                  = PromptContext.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:contexts:$id"
   override def extractId(value: PromptContext): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/embeddingmodel.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/embeddingmodel.scala
@@ -2,16 +2,16 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.EmbeddingModelClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.EmbeddingModelClientDecorators
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -35,7 +35,7 @@ case class EmbeddingModel(
   override def theTags: Seq[String]             = tags
   override def theMetadata: Map[String, String] = metadata
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
-  def getEmbeddingModelClient()(implicit env: Env): Option[EmbeddingModelClient] = {
+  def getEmbeddingModelClient()(using env: Env): Option[EmbeddingModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val options = config.select("options").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
@@ -66,13 +66,13 @@ object EmbeddingModel {
   val clientBuilders: Map[String, EmbeddingModel.ClientContext => Option[EmbeddingModelClient]] = {
     val explicit: Map[String, EmbeddingModel.ClientContext => Option[EmbeddingModelClient]] = Map(
       "openai" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(30.seconds), providerName = "OpenAI", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "azure-openai" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val resourceName = connection.select("resource_name").as[String]
         val deploymentId = connection.select("deployment_id").as[String]
         val version = connection.select("api_version").asOpt[String].getOrElse("v1")
@@ -88,67 +88,67 @@ object EmbeddingModel {
         }
       },
       "azure-ai-foundry" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(AzureAiFoundry.baseUrl), token, timeout.getOrElse(30.seconds), providerName = "Azure AI Foundry", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "scaleway" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(ScalewayApi.baseUrl), token, timeout.getOrElse(10.seconds), providerName = "Scaleway", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "cloud-temple" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(CloudTemple.baseUrl), token, timeout.getOrElse(10.seconds), providerName = "Cloud Temple", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "deepseek" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(DeepSeekApi.baseUrl), token, timeout.getOrElse(10.seconds), providerName = "Deepseek", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "gemini" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(GeminiApi.baseUrl), token, timeout.getOrElse(10.seconds), providerName = "gemini", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "huggingface" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(HuggingfaceApi.baseUrl), token, timeout.getOrElse(10.seconds), providerName = "huggingface", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "mistral" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new MistralAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(30.seconds), env = env)
         val opts = MistralAiEmbeddingModelClientOptions.fromJson(options)
         new MistralAiEmbeddingModelClient(api, opts, id).some
       },
       "ollama" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OllamaAiApi(baseUrl.getOrElse(OllamaAiApi.baseUrl), token.some.filterNot(_ == "xxx"), timeout.getOrElse(10.seconds), env = env)
         val opts = OllamaEmbeddingModelClientOptions.fromJson(options)
         new OllamaEmbeddingModelClient(api, opts, id).some
       },
       "x-ai" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new XAiApi(baseUrl.getOrElse(XAiApi.baseUrl), token, timeout.getOrElse(10.seconds), env = env)
         val opts = XAiEmbeddingModelClientOptions.fromJson(options)
         new XAiEmbeddingModelClient(api, opts, id).some
       },
       "cohere" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new CohereAiApi(baseUrl.getOrElse(CohereAiApi.baseUrl), token, timeout.getOrElse(10.seconds), env = env)
         val opts = CohereAiEmbeddingModelClientOptions.fromJson(options)
         new CohereAiEmbeddingModelClient(api, opts, id).some
       },
       "openai-compatible" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         // generic OpenAI-compatible embedding endpoint: base url, display name, headers and param
         // mappings are all driven by the connection config (dynamic name).
         val providerName = connection.select("provider_name").asOpt[String]
@@ -171,20 +171,20 @@ object EmbeddingModel {
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "ovh-ai-endpoints" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(OVHAiEndpointsApi.unifiedUrl), token, timeout.getOrElse(10.seconds), providerName = "OVH", env = env)
         val opts = OpenAiEmbeddingModelClientOptions.fromJson(options)
         new OpenAiEmbeddingModelClient(api, opts, id).some
       },
       "all-minilm-l6-v2" -> { (c: ClientContext) =>
-        import c._
+        import c.*
         new AllMiniLmL6V2EmbeddingModelClient(options, id).some
       },
     )
     val likes: Map[String, EmbeddingModel.ClientContext => Option[EmbeddingModelClient]] =
       OpenAiLikeProviders.all.filter(_.supportsEmbeddings).map { provDef =>
         provDef.id -> { (c: ClientContext) =>
-          import c._
+          import c.*
           val api = new OpenAiApi(
             _baseUrl = baseUrl.getOrElse(provDef.baseUrl),
             token = token,
@@ -244,7 +244,7 @@ object EmbeddingModel {
         extractIdf = c => datastores.embeddingModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("openai") => EmbeddingModel(
               id = IdGenerator.namedId("embedding-model", env),
@@ -316,7 +316,7 @@ class KvEmbeddingModelsDataStore(extensionId: AdminExtensionId, redisCli: RedisL
   extends EmbeddingModelsDataStore
     with RedisLikeStore[EmbeddingModel] {
   override def fmt: Format[EmbeddingModel]                  = EmbeddingModel.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:embmods:$id"
   override def extractId(value: EmbeddingModel): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/embeddingstore.scala
@@ -1,19 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.EmbeddingStoreClient
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
 
 case class EmbeddingStore(
@@ -32,7 +30,7 @@ case class EmbeddingStore(
   override def theDescription: String           = description
   override def theTags: Seq[String]             = tags
   override def theMetadata: Map[String, String] = metadata
-  def getEmbeddingStoreClient()(implicit env: Env): Option[EmbeddingStoreClient] = {
+  def getEmbeddingStoreClient()(using env: Env): Option[EmbeddingStoreClient] = {
     provider.toLowerCase() match {
       case "local" => new LocalEmbeddingStoreClient(config, id).some
       case "chromadb" | "chroma" => new ChromaDbEmbeddingStoreClient(config, id).some
@@ -89,7 +87,7 @@ object EmbeddingStore {
         extractIdf = c => datastores.embeddingStoresDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case _ => EmbeddingStore(
               id = IdGenerator.namedId("embedding-store", env),
@@ -131,7 +129,7 @@ class KvEmbeddingStoresDataStore(extensionId: AdminExtensionId, redisCli: RedisL
   extends EmbeddingStoresDataStore
     with RedisLikeStore[EmbeddingStore] {
   override def fmt: Format[EmbeddingStore]                  = EmbeddingStore.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:embstores:$id"
   override def extractId(value: EmbeddingStore): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/functions.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/functions.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object LlmFunctions {
 
-  def nameToFunction(functionIds: Seq[String])(implicit env: Env): Map[String, String] = {
+  def nameToFunction(functionIds: Seq[String])(using env: Env): Map[String, String] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     functionIds.map { fid =>
       val function = ext.states.toolFunction(fid).get
@@ -17,16 +17,16 @@ object LlmFunctions {
     }.toMap
   }
 
-  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val wasmFunctions = functions.filter(_.isWasm)
     val searchFunctions = functions.filter(_.isSearchEngine)
     val a2aConnectors = functions.filter(_.isA2A)
     val mcpConnectors = functions.filterNot(f => f.isWasm || f.isSearchEngine || f.isA2A)
-    val inlineFunctionsF = LlmToolFunction._callInlineToolsOpenai(wasmFunctions.filter(_.isInline), providerName, attrs)(ec, env)
-    val wasmFunctionsF = LlmToolFunction._callToolsOpenai(wasmFunctions.filterNot(_.isInline), providerName, attrs, nameToFunction)(ec, env)
-    val mcpConnectorsF = McpSupport.callToolsOpenai(mcpConnectors, conns, providerName, attrs)(ec, env)
-    val a2aConnectorsF = A2ASupport.callToolsOpenai(a2aConnectors, providerName, attrs)(ec, env)
-    val searchFunctionsF = SearchEngineSupport.callToolsOpenai(searchFunctions, providerName, attrs)(ec, env)
+    val inlineFunctionsF = LlmToolFunction._callInlineToolsOpenai(wasmFunctions.filter(_.isInline), providerName, attrs)(using ec, env)
+    val wasmFunctionsF = LlmToolFunction._callToolsOpenai(wasmFunctions.filterNot(_.isInline), providerName, attrs, nameToFunction)(using ec, env)
+    val mcpConnectorsF = McpSupport.callToolsOpenai(mcpConnectors, conns, providerName, attrs)(using ec, env)
+    val a2aConnectorsF = A2ASupport.callToolsOpenai(a2aConnectors, providerName, attrs)(using ec, env)
+    val searchFunctionsF = SearchEngineSupport.callToolsOpenai(searchFunctions, providerName, attrs)(using ec, env)
     for {
       wasmFunctionsR <- wasmFunctionsF
       mcpConnectorsR <- mcpConnectorsF
@@ -36,16 +36,16 @@ object LlmFunctions {
     } yield inlineFunctionsR ++ wasmFunctionsR ++ mcpConnectorsR ++ a2aConnectorsR ++ searchFunctionsR
   }
 
-  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val wasmFunctions = functions.filter(_.isWasm)
     val searchFunctions = functions.filter(_.isSearchEngine)
     val a2aConnectors = functions.filter(_.isA2A)
     val mcpConnectors = functions.filterNot(f => f.isWasm || f.isSearchEngine || f.isA2A)
-    val inlineFunctionsF = LlmToolFunction._callInlineToolsOllama(wasmFunctions.filter(_.isInline), attrs)(ec, env)
-    val wasmFunctionsF = LlmToolFunction._callToolsOllama(wasmFunctions, attrs, nameToFunction)(ec, env)
-    val mcpConnectorsF = McpSupport.callToolsOllama(mcpConnectors, conns, attrs)(ec, env)
-    val a2aConnectorsF = A2ASupport.callToolsOllama(a2aConnectors, attrs)(ec, env)
-    val searchFunctionsF = SearchEngineSupport.callToolsOllama(searchFunctions, attrs)(ec, env)
+    val inlineFunctionsF = LlmToolFunction._callInlineToolsOllama(wasmFunctions.filter(_.isInline), attrs)(using ec, env)
+    val wasmFunctionsF = LlmToolFunction._callToolsOllama(wasmFunctions, attrs, nameToFunction)(using ec, env)
+    val mcpConnectorsF = McpSupport.callToolsOllama(mcpConnectors, conns, attrs)(using ec, env)
+    val a2aConnectorsF = A2ASupport.callToolsOllama(a2aConnectors, attrs)(using ec, env)
+    val searchFunctionsF = SearchEngineSupport.callToolsOllama(searchFunctions, attrs)(using ec, env)
     for {
       wasmFunctionsR <- wasmFunctionsF
       mcpConnectorsR <- mcpConnectorsF
@@ -55,16 +55,16 @@ object LlmFunctions {
     } yield inlineFunctionsR ++ wasmFunctionsR ++ mcpConnectorsR ++ a2aConnectorsR ++ searchFunctionsR
   }
 
-  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val wasmFunctions = functions.filter(_.isWasm)
     val searchFunctions = functions.filter(_.isSearchEngine)
     val a2aConnectors = functions.filter(_.isA2A)
     val mcpConnectors = functions.filterNot(f => f.isWasm || f.isSearchEngine || f.isA2A)
-    val inlineFunctionsF = LlmToolFunction._callInlineToolsAnthropic(wasmFunctions.filter(_.isInline), providerName, attrs)(ec, env)
-    val wasmFunctionsF = LlmToolFunction._callToolsAnthropic(wasmFunctions, providerName, attrs, nameToFunction)(ec, env)
-    val mcpConnectorsF = McpSupport.callToolsAnthropic(mcpConnectors, conns, providerName, attrs)(ec, env)
-    val a2aConnectorsF = A2ASupport.callToolsAnthropic(a2aConnectors, attrs)(ec, env)
-    val searchFunctionsF = SearchEngineSupport.callToolsAnthropic(searchFunctions, providerName, attrs)(ec, env)
+    val inlineFunctionsF = LlmToolFunction._callInlineToolsAnthropic(wasmFunctions.filter(_.isInline), providerName, attrs)(using ec, env)
+    val wasmFunctionsF = LlmToolFunction._callToolsAnthropic(wasmFunctions, providerName, attrs, nameToFunction)(using ec, env)
+    val mcpConnectorsF = McpSupport.callToolsAnthropic(mcpConnectors, conns, providerName, attrs)(using ec, env)
+    val a2aConnectorsF = A2ASupport.callToolsAnthropic(a2aConnectors, attrs)(using ec, env)
+    val searchFunctionsF = SearchEngineSupport.callToolsAnthropic(searchFunctions, providerName, attrs)(using ec, env)
     for {
       wasmFunctionsR <- wasmFunctionsF
       mcpConnectorsR <- mcpConnectorsF
@@ -74,16 +74,16 @@ object LlmFunctions {
     } yield inlineFunctionsR ++ wasmFunctionsR ++ mcpConnectorsR ++ a2aConnectorsR ++ searchFunctionsR
   }
 
-  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], conns: Seq[String], providerName: String, fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     val wasmFunctions = functions.filter(_.isWasm)
     val searchFunctions = functions.filter(_.isSearchEngine)
     val a2aConnectors = functions.filter(_.isA2A)
     val mcpConnectors = functions.filterNot(f => f.isWasm || f.isSearchEngine || f.isA2A)
-    val inlineFunctionsF = LlmToolFunction.callInlineToolsCohere(wasmFunctions.filter(_.isInline), providerName, fmap, attrs)(ec, env)
-    val wasmFunctionsF = LlmToolFunction.callToolsCohere(wasmFunctions, providerName, fmap, attrs, nameToFunction)(ec, env)
-    val mcpConnectorsF = McpSupport.callToolsCohere(mcpConnectors, conns, providerName, fmap, attrs)(ec, env)
-    val a2aConnectorsF = A2ASupport.callToolsCohere(a2aConnectors, fmap, providerName, attrs)(ec, env)
-    val searchFunctionsF = SearchEngineSupport.callToolsCohere(searchFunctions, providerName, attrs)(ec, env)
+    val inlineFunctionsF = LlmToolFunction.callInlineToolsCohere(wasmFunctions.filter(_.isInline), providerName, fmap, attrs)(using ec, env)
+    val wasmFunctionsF = LlmToolFunction.callToolsCohere(wasmFunctions, providerName, fmap, attrs, nameToFunction)(using ec, env)
+    val mcpConnectorsF = McpSupport.callToolsCohere(mcpConnectors, conns, providerName, fmap, attrs)(using ec, env)
+    val a2aConnectorsF = A2ASupport.callToolsCohere(a2aConnectors, fmap, providerName, attrs)(using ec, env)
+    val searchFunctionsF = SearchEngineSupport.callToolsCohere(searchFunctions, providerName, attrs)(using ec, env)
     for {
       wasmFunctionsR <- wasmFunctionsF
       mcpConnectorsR <- mcpConnectorsF
@@ -93,35 +93,35 @@ object LlmFunctions {
     } yield inlineFunctionsR ++ wasmFunctionsR ++ mcpConnectorsR ++ a2aConnectorsR ++ searchFunctionsR
   }
 
-  def toolsWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): JsObject = {
+  def toolsWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): JsObject = {
     val tools: Seq[JsObject] = LlmToolFunction._tools(wasmFunctions) ++ LlmToolFunction._inlineTools(inlineFunctions, attrs) ++ McpSupport.tools(mcpConnectors, includeFunctions, excludeFunctions, attrs) ++ A2ASupport.tools(attrs) ++ SearchEngineSupport.tools(searchEngines)
     Json.obj(
       "tools" -> tools
     )
   }
 
-  def tools(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): JsObject = {
+  def tools(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): JsObject = {
     val tools: Seq[JsObject] = LlmToolFunction._tools(wasmFunctions) ++ McpSupport.tools(mcpConnectors, includeFunctions, excludeFunctions, attrs) ++ A2ASupport.tools(attrs) ++ SearchEngineSupport.tools(searchEngines)
     Json.obj(
       "tools" -> tools
     )
   }
 
-  def toolsAnthropic(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): JsObject = {
+  def toolsAnthropic(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): JsObject = {
     val tools: Seq[JsObject] = LlmToolFunction._toolsAnthropic(wasmFunctions) ++ McpSupport.toolsAnthropic(mcpConnectors, includeFunctions, excludeFunctions, attrs) ++ A2ASupport.toolsAnthropic(attrs) ++ SearchEngineSupport.toolsAnthropic(searchEngines)
     Json.obj(
       "tools" -> tools
     )
   }
 
-  def toolsAnthropicWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): JsObject = {
+  def toolsAnthropicWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): JsObject = {
     val tools: Seq[JsObject] = LlmToolFunction._toolsAnthropic(wasmFunctions) ++ LlmToolFunction._inlineToolsAnthropic(inlineFunctions, attrs) ++ McpSupport.toolsAnthropic(mcpConnectors, includeFunctions, excludeFunctions, attrs) ++ A2ASupport.toolsAnthropic(attrs) ++ SearchEngineSupport.toolsAnthropic(searchEngines)
     Json.obj(
       "tools" -> tools
     )
   }
 
-  def toolsCohere(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): (JsObject, Map[String, String]) = {
+  def toolsCohere(wasmFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): (JsObject, Map[String, String]) = {
     val (wasmTools, wasmMap) = LlmToolFunction.toolsCohere(wasmFunctions)
     val (mcpTools, mcpMap) =  McpSupport.toolsCohere(mcpConnectors, includeFunctions, excludeFunctions, attrs)
     val (a2aTools, a2aMap) = A2ASupport.toolsCohere(attrs)
@@ -133,7 +133,7 @@ object LlmFunctions {
     ), map)
   }
 
-  def toolsCohereWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(implicit ec: ExecutionContext, env: Env): (JsObject, Map[String, String]) = {
+  def toolsCohereWithInline(wasmFunctions: Seq[String], inlineFunctions: Seq[String], mcpConnectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap, searchEngines: Seq[String] = Seq.empty)(using ec: ExecutionContext, env: Env): (JsObject, Map[String, String]) = {
     val (wasmTools, wasmMap) = LlmToolFunction.toolsCohere(wasmFunctions)
     val (mcpTools, mcpMap) =  McpSupport.toolsCohere(mcpConnectors, includeFunctions, excludeFunctions, attrs)
     val (a2aTools, a2aMap) = A2ASupport.toolsCohere(attrs)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/image.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/image.scala
@@ -2,16 +2,16 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.ImageModelClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.ImageModelClientDecorators
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -35,7 +35,7 @@ case class ImageModel(
   override def theTags: Seq[String]             = tags
   override def theMetadata: Map[String, String] = metadata
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
-  def getImageModelClient()(implicit env: Env): Option[ImageModelClient] = {
+  def getImageModelClient()(using env: Env): Option[ImageModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val genOptions = config.select("options").select("generation").asOpt[JsObject].getOrElse(Json.obj())
     val editOptions = config.select("options").select("edition").asOpt[JsObject].getOrElse(Json.obj())
@@ -64,34 +64,34 @@ object ImageModel {
   // `supportedProviders` (and the providers catalog) is derived from these keys.
   val clientBuilders: Map[String, ImageModel.ClientContext => Option[ImageModelClient]] = Map(
     "openai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "OpenAI", env = env)
       val opts = OpenAiImageModelClientOptions.fromJson(genOptions)
       val editOpts = OpenAiImageEditionModelClientOptions.fromJson(editOptions)
       new OpenAiImageModelClient(api, opts, editOpts, id).some
     },
     "gemini" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(GeminiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Gemini", env = env)
       val opts = OpenAiImageModelClientOptions.fromJson(genOptions)
       val editOpts = OpenAiImageEditionModelClientOptions.fromJson(editOptions)
       new OpenAiImageModelClient(api, opts, editOpts, id).some
     },
     "cloud-temple" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(CloudTemple.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Cloud Temple", env = env)
       val opts = OpenAiImageModelClientOptions.fromJson(genOptions)
       val editOpts = OpenAiImageEditionModelClientOptions.fromJson(editOptions)
       new OpenAiImageModelClient(api, opts, editOpts, id).some
     },
     "x-ai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new XAiApi(baseUrl.getOrElse(XAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = XAiImageModelClientOptions.fromJson(genOptions)
       new XAiImageModelClient(api, opts, id).some
     },
     "azure-openai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val resourceName = connection.select("resource_name").as[String]
       val deploymentId = connection.select("deployment_id").as[String]
       val version = connection.select("api_version").asOpt[String].getOrElse("2024-02-01")
@@ -102,32 +102,32 @@ object ImageModel {
       new AzureOpenAiImageModelClient(api, opts, id).some
     },
     "luma" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new LumaApi(baseUrl.getOrElse(LumaApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = LumaImageModelClientOptions.fromJson(genOptions)
       new LumaImageModelClient(api, opts, id).some
     },
     "leonardo-ai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new LeonardoAIApi(baseUrl.getOrElse(LeonardoAIApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = LeonardoAIImagesGenModelClientOptions.fromJson(genOptions)
       new LeonardoAIImageModelClient(api, opts, id).some
     },
     "hive" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new HiveApi(baseUrl.getOrElse(HiveApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = HiveImageModelClientOptions.fromJson(genOptions)
       new HiveImageModelClient(api, opts, id).some
     },
     "openrouter" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenRouterApi(baseUrl.getOrElse(OpenRouterApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = OpenRouterImageModelClientOptions.fromJson(genOptions)
       val editOpts = OpenRouterImageModelClientOptions.fromJson(editOptions)
       new OpenRouterImageModelClient(api, opts, editOpts, id).some
     },
     "openai-compatible" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // generic OpenAI-compatible image endpoint: base url, display name, headers and param
       // mappings are all driven by the connection config (dynamic name).
       val providerName = connection.select("provider_name").asOpt[String]
@@ -151,7 +151,7 @@ object ImageModel {
       new OpenAiImageModelClient(api, opts, editOpts, id).some
     },
     "ovh-ai-endpoints" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // OVH AI Endpoints images go through their unified OpenAI-compatible API
       val api = new OpenAiApi(baseUrl.getOrElse(OVHAiEndpointsApi.unifiedUrl), token, timeout.getOrElse(3.minutes), providerName = "OVH", env = env)
       val opts = OpenAiImageModelClientOptions.fromJson(genOptions)
@@ -204,7 +204,7 @@ object ImageModel {
         extractIdf = c => datastores.imageModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("openai") => ImageModel(
               id = IdGenerator.namedId("image-model", env),
@@ -280,7 +280,7 @@ class KvImageModelsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike,
   extends ImageModelsDataStore
     with RedisLikeStore[ImageModel] {
   override def fmt: Format[ImageModel]                  = ImageModel.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:imagemodels:$id"
   override def extractId(value: ImageModel): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/mcp.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/mcp.scala
@@ -1,6 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.agents.InlineFunctions
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.McpConnectorTransportKind.Stdio
 import com.cloud.apim.otoroshi.extensions.aigateway.mcp.{MetaMcpClient, OpenApiMcpClient, WsMcpTransport}
@@ -9,8 +9,8 @@ import dev.langchain4j.agent.tool.{ToolExecutionRequest, ToolSpecification}
 import dev.langchain4j.mcp.client.transport.http.{HttpMcpTransport, StreamableHttpMcpTransport}
 import dev.langchain4j.mcp.client.transport.stdio.StdioMcpTransport
 import dev.langchain4j.mcp.client.transport.websocket.WebSocketMcpTransport
-import dev.langchain4j.mcp.client._
-import dev.langchain4j.model.chat.request.json._
+import dev.langchain4j.mcp.client.*
+import dev.langchain4j.model.chat.request.json.*
 import otoroshi.api.{GenericResourceAccessApiWithState, Resource, ResourceVersion}
 import otoroshi.env.Env
 import otoroshi.events.AuditEvent
@@ -18,11 +18,11 @@ import otoroshi.models.{EntityLocation, EntityLocationSupport}
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
 import otoroshi.storage.{BasicStore, RedisLike, RedisLikeStore}
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi.utils.{JsonPathValidator, TypedMap}
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiExtension, AiGatewayExtensionDatastores, AiGatewayExtensionState}
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.McpOAuthFilterUtils
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -30,8 +30,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{Duration, DurationLong, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
+import play.api.libs.ws.WSBodyWritables.given
 
 sealed trait McpConnectorTransportKind {
   def name: String
@@ -163,7 +164,7 @@ case class McpConnectorCategoryRules(rules: Map[String, Seq[JsonPathValidator]] 
   def rulesFor(name: String): Option[Seq[JsonPathValidator]] = {
     rules.get(name).orElse(rules.get("*"))
   }
-  def validate(name: String, ctx: JsValue)(implicit env: Env): Boolean = {
+  def validate(name: String, ctx: JsValue)(using env: Env): Boolean = {
     rulesFor(name) match {
       case None => true
       case Some(validators) => validators.forall(_.validate(ctx))
@@ -222,10 +223,10 @@ object McpConnectorRules {
     )
     override def reads(json: JsValue): JsResult[McpConnectorRules] = Try {
       McpConnectorRules(
-        toolRules = json.select("tool_rules").asOpt(McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
-        promptRules = json.select("prompt_rules").asOpt(McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
-        resourceRules = json.select("resource_rules").asOpt(McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
-        resourceTemplatesRules = json.select("resource_templates_rules").asOpt(McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
+        toolRules = json.select("tool_rules").asOpt(using McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
+        promptRules = json.select("prompt_rules").asOpt(using McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
+        resourceRules = json.select("resource_rules").asOpt(using McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
+        resourceTemplatesRules = json.select("resource_templates_rules").asOpt(using McpConnectorCategoryRules.format).getOrElse(McpConnectorCategoryRules.empty),
       )
     } match {
       case Failure(ex) => JsError(ex.getMessage)
@@ -239,7 +240,7 @@ object McpConnectorRules {
 // the MCP *server*/exposure side. Gated per-connector by `McpConnector.auditEvents`.
 object McpClientAudit {
 
-  def emit(connector: McpConnector, operation: String, request: JsValue, duration: Long, error: Option[String], attrs: TypedMap, response: JsValue = JsNull)(implicit env: Env): Unit = {
+  def emit(connector: McpConnector, operation: String, request: JsValue, duration: Long, error: Option[String], attrs: TypedMap, response: JsValue = JsNull)(using env: Env): Unit = {
     if (!connector.auditEvents) return
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
@@ -269,7 +270,7 @@ object McpClientAudit {
   // Real-time metrics for upstream MCP calls (always on when env metrics are enabled, independent of the
   // opt-in audit events). Flat metric names (Otoroshi's String metric API carries no tags), the operation
   // is encoded in the name. Exposed through Otoroshi's metrics endpoint (prometheus / json export).
-  def markMetrics(operation: String, durationMs: Long, isError: Boolean)(implicit env: Env): Unit = {
+  def markMetrics(operation: String, durationMs: Long, isError: Boolean)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     val op = operation.replace('/', '.')
     env.metrics.counterInc("mcp.client.calls")
@@ -284,7 +285,7 @@ object McpClientAudit {
   // wraps an upstream operation: times it, records metrics (always), and emits a success/error audit event
   // when it completes (only if the connector has audit events enabled).
   // `toResponse` turns the result into the json logged as mcp_response (the full raw upstream payload).
-  def audited[T](connector: McpConnector, operation: String, request: JsValue, attrs: TypedMap)(toResponse: T => JsValue)(f: => Future[T])(implicit ec: ExecutionContext, env: Env): Future[T] = {
+  def audited[T](connector: McpConnector, operation: String, request: JsValue, attrs: TypedMap)(toResponse: T => JsValue)(f: => Future[T])(using ec: ExecutionContext, env: Env): Future[T] = {
     val start = System.currentTimeMillis()
     f.andThen {
       case Success(v) =>
@@ -358,7 +359,7 @@ case class McpConnector(
     }
   }
 
-  private def clientPool(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): ConcurrentLinkedQueue[McpClient] = synchronized {
+  private def clientPool(attrs: TypedMap)(using ec: ExecutionContext, env: Env): ConcurrentLinkedQueue[McpClient] = synchronized {
     val transportSha = transport.json.stringify.sha256
     McpConnector.connectorsCache.get(id) match {
       case Some((cli, _, hash, _)) if hash == transportSha => cli
@@ -381,7 +382,7 @@ case class McpConnector(
 
   // EL-evaluated transport + computed headers (incl. forwardAuth / {input_token} substitution).
   // Shared by buildClient (langchain4j path) and the raw JSON-RPC passthrough (Http kind).
-  private def resolvedTransportAndHeaders(attrs: TypedMap)(implicit env: Env): (McpConnectorTransport, Map[String, String]) = {
+  private def resolvedTransportAndHeaders(attrs: TypedMap)(using env: Env): (McpConnectorTransport, Map[String, String]) = {
     val finaltransport = Try(McpConnectorTransport.format.reads(transport.json.stringify.evaluateEl(attrs).parseJson).getOrElse(transport)).getOrElse(transport)
     val inputToken: String = if (forwardAuth) {
       attrs.get(McpOAuthFilterUtils.McpUserAuthTokenKey)
@@ -392,7 +393,7 @@ case class McpConnector(
         )
         .getOrElse("--")
     } else "--"
-    val headers: Map[String, String] = if (forwardAuth) finaltransport.sseOptions.headers.mapValues(_.applyOnWithPredicate(_.contains("{input_token}"))(_.replace("{input_token}", inputToken))) else transport.sseOptions.headers
+    val headers: Map[String, String] = if (forwardAuth) finaltransport.sseOptions.headers.view.mapValues(_.applyOnWithPredicate(_.contains("{input_token}"))(_.replace("{input_token}", inputToken))).toMap else transport.sseOptions.headers
     (finaltransport, headers)
   }
 
@@ -412,9 +413,9 @@ case class McpConnector(
     }
   }
 
-  private def rawHttpPost(url: String, headers: Seq[(String, String)], timeout: FiniteDuration, body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[(Option[String], Seq[JsValue])] = {
+  private def rawHttpPost(url: String, headers: Seq[(String, String)], timeout: FiniteDuration, body: JsValue)(using ec: ExecutionContext, env: Env): Future[(Option[String], Seq[JsValue])] = {
     env.Ws.url(url)
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .withMethod("POST")
       .withBody(body.stringify)
@@ -432,7 +433,7 @@ case class McpConnector(
 
   // raw JSON-RPC call to the upstream streamable-HTTP MCP server: initialize handshake (to obtain the
   // Mcp-Session-Id), then the actual request. Returns the raw `result` object of the response.
-  def rawHttpRpc(method: String, params: JsValue, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[JsValue] = {
+  def rawHttpRpc(method: String, params: JsValue, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[JsValue] = {
     val (finaltransport, hdrs) = resolvedTransportAndHeaders(attrs)
     val opts = finaltransport.sseOptions
     val url = opts.url
@@ -468,7 +469,7 @@ case class McpConnector(
   }
 
   // raw, full-fidelity tools/list for Http connectors (preserves _meta/annotations/outputSchema/title).
-  def rawListTools(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsObject]] = {
+  def rawListTools(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsObject]] = {
     val ctx = attrs.json
     McpClientAudit.audited[Seq[JsObject]](this, "tools/list", Json.obj("raw" -> true), attrs)(rs => Json.obj("tools" -> JsArray(rs))) {
       rawHttpRpc("tools/list", Json.obj(), attrs).map { result =>
@@ -481,7 +482,7 @@ case class McpConnector(
   }
 
   // raw, full-fidelity tools/call for Http connectors (preserves content/structuredContent/_meta/isError).
-  def rawCallTool(name: String, args: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[JsObject] = {
+  def rawCallTool(name: String, args: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[JsObject] = {
     val ctx = attrs.json
     McpClientAudit.audited[JsObject](this, "tools/call", Json.obj("raw" -> true, "name" -> name, "arguments" -> (Try(Json.parse(args)).getOrElse(JsString(args)): JsValue)), attrs)(res => res) {
       if (matchesByName(name, includeFunctions, excludeFunctions) && matchesRules(name, ctx, allowRules.toolRules, disallowRules.toolRules)) {
@@ -496,7 +497,7 @@ case class McpConnector(
     }
   }
 
-  private def buildClient(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): McpClient = {
+  private def buildClient(attrs: TypedMap)(using ec: ExecutionContext, env: Env): McpClient = {
     println(s"building McpClient for ${name}")
     if (transport.kind == McpConnectorTransportKind.Meta) {
       return new MetaMcpClient(this, env, ec)
@@ -578,7 +579,7 @@ case class McpConnector(
     }
   }
 
-  private def matchesRules(name: String, ctx: JsValue, allowCategory: McpConnectorCategoryRules, disallowCategory: McpConnectorCategoryRules)(implicit env: Env): Boolean = {
+  private def matchesRules(name: String, ctx: JsValue, allowCategory: McpConnectorCategoryRules, disallowCategory: McpConnectorCategoryRules)(using env: Env): Boolean = {
     val disallowed = disallowCategory.rulesFor(name) match {
       case None => false
       case Some(validators) => validators.forall(_.validate(ctx))
@@ -590,52 +591,52 @@ case class McpConnector(
     }
   }
 
-  private def matchesTool(tool: ToolSpecification, ctx: JsValue, attrs: TypedMap)(implicit env: Env): Boolean = {
+  private def matchesTool(tool: ToolSpecification, ctx: JsValue, attrs: TypedMap)(using env: Env): Boolean = {
     matchesByName(tool.name(), includeFunctions, excludeFunctions) &&
       matchesRules(tool.name(), ctx, allowRules.toolRules, disallowRules.toolRules)
   }
 
-  def matchesResource(resource: McpResource, ctx: JsValue, attrs: TypedMap)(implicit env: Env): Boolean = {
+  def matchesResource(resource: McpResource, ctx: JsValue, attrs: TypedMap)(using env: Env): Boolean = {
     matchesByName(resource.name(), includeResources, excludeResources) &&
       matchesRules(resource.name(), ctx, allowRules.resourceRules, disallowRules.resourceRules)
   }
-  def matchesResourceTemplate(resourceTemplate: McpResourceTemplate, ctx: JsValue, attrs: TypedMap)(implicit env: Env): Boolean = {
+  def matchesResourceTemplate(resourceTemplate: McpResourceTemplate, ctx: JsValue, attrs: TypedMap)(using env: Env): Boolean = {
     matchesByName(resourceTemplate.name(), includeResourceTemplates, excludeResourceTemplates) &&
       matchesByName(resourceTemplate.uriTemplate(), includeResourceTemplateUris, excludeResourceTemplateUris) &&
       matchesRules(resourceTemplate.name(), ctx, allowRules.resourceTemplatesRules, disallowRules.resourceTemplatesRules)
   }
-  def matchesPrompt(prompt: McpPrompt, ctx: JsValue, attrs: TypedMap)(implicit env: Env): Boolean = {
+  def matchesPrompt(prompt: McpPrompt, ctx: JsValue, attrs: TypedMap)(using env: Env): Boolean = {
     matchesByName(prompt.name(), includePrompts, excludePrompts) &&
       matchesRules(prompt.name(), ctx, allowRules.promptRules, disallowRules.promptRules)
   }
 
-  def listToolsBlocking(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Seq[ToolSpecification] = Await.result(listTools(attrs), 10.seconds)
-  def listResources(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[McpResource]] = {
+  def listToolsBlocking(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Seq[ToolSpecification] = Await.result(listTools(attrs), 10.seconds)
+  def listResources(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[McpResource]] = {
     val ctx = attrs.json
     McpClientAudit.audited[Seq[McpResource]](this, "resources/list", Json.obj(), attrs)(rs => Json.obj("resources" -> JsArray(rs.map(McpSupport.resourceToJson)))) {
       withClient(attrs)(_.listResources().asScala.toSeq.filter(r => matchesResource(r, ctx, attrs)))
     }
   }
-  def listResourceTemplates(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[McpResourceTemplate]] = {
+  def listResourceTemplates(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[McpResourceTemplate]] = {
     val ctx = attrs.json
     McpClientAudit.audited[Seq[McpResourceTemplate]](this, "resources/templates/list", Json.obj(), attrs)(rs => Json.obj("templates" -> JsArray(rs.map(McpSupport.resourceTemplateToJson)))) {
       withClient(attrs)(_.listResourceTemplates().asScala.toSeq.filter(r => matchesResourceTemplate(r, ctx, attrs)))
     }
   }
-  def listPrompts(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[McpPrompt]] = {
+  def listPrompts(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[McpPrompt]] = {
     val ctx = attrs.json
     McpClientAudit.audited[Seq[McpPrompt]](this, "prompts/list", Json.obj(), attrs)(rs => Json.obj("prompts" -> JsArray(rs.map(McpSupport.promptToJson)))) {
       withClient(attrs)(_.listPrompts().asScala.toSeq.filter(r => matchesPrompt(r, ctx, attrs)))
     }
   }
-  def listTools(attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[ToolSpecification]] = {
+  def listTools(attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[ToolSpecification]] = {
     val ctx = attrs.json
     McpClientAudit.audited[Seq[ToolSpecification]](this, "tools/list", Json.obj(), attrs)(rs => Json.obj("tools" -> JsArray(rs.map(McpSupport.toolSpecToJson)))) {
       withClient(attrs)(_.listTools().asScala.toSeq.filter(r => matchesTool(r, ctx, attrs)))
     }
   }
 
-  def readResource(uri: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Option[McpReadResourceResult]] = {
+  def readResource(uri: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Option[McpReadResourceResult]] = {
     val ctx = attrs.json
     if (matchesRules(uri, ctx, allowRules.resourceRules, disallowRules.resourceRules)) {
       McpClientAudit.audited[McpReadResourceResult](this, "resources/read", Json.obj("uri" -> uri), attrs)(r => Json.obj("contents" -> JsArray(r.contents().asScala.toSeq.map(McpSupport.resourceContentsToJson)))) {
@@ -645,7 +646,7 @@ case class McpConnector(
       None.vfuture
     }
   }
-  def getPrompt(name: String, arguments: Map[String, Object], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Option[McpGetPromptResult]] = {
+  def getPrompt(name: String, arguments: Map[String, Object], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Option[McpGetPromptResult]] = {
     val ctx = attrs.json
     if (matchesByName(name, includePrompts, excludePrompts) && matchesRules(name, ctx, allowRules.promptRules, disallowRules.promptRules)) {
       val request = Json.obj("name" -> name, "arguments" -> JsArray(arguments.keys.toSeq.map(JsString.apply)))
@@ -662,7 +663,7 @@ case class McpConnector(
       None.vfuture
     }
   }
-  def call(name: String, args: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = McpClientAudit.audited[String](this, "tools/call", Json.obj("name" -> name, "arguments" -> (Try(Json.parse(args)).getOrElse(JsString(args)): JsValue)), attrs)(res => Json.obj("result" -> res)) {
+  def call(name: String, args: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = McpClientAudit.audited[String](this, "tools/call", Json.obj("name" -> name, "arguments" -> (Try(Json.parse(args)).getOrElse(JsString(args)): JsValue)), attrs)(res => Json.obj("result" -> res)) {
     val ctx = attrs.json
     if (matchesByName(name, includeFunctions, excludeFunctions) && matchesRules(name, ctx, allowRules.toolRules, disallowRules.toolRules)) {
       val request = ToolExecutionRequest.builder().id(UUID.randomUUID().toString()).name(name).arguments(args).build()
@@ -705,7 +706,7 @@ case class McpConnector(
     }
   }
 
-  private def withClient[T](attrs: TypedMap)(f: McpClient => T)(implicit ec: ExecutionContext, env: Env): Future[T] = {
+  private def withClient[T](attrs: TypedMap)(f: McpClient => T)(using ec: ExecutionContext, env: Env): Future[T] = {
     if (!enabled) {
       Future.failed(new RuntimeException("Mcp client is not enabled"))
     } else if (pool.size <= 0) {
@@ -809,7 +810,7 @@ object McpConnector {
         metadata = (json \ "metadata").asOpt[Map[String, String]].getOrElse(Map.empty),
         tags = (json \ "tags").asOpt[Seq[String]].getOrElse(Seq.empty[String]),
         pool = McpConnectorPoolSettings((json \ "pool" \ "size").asOpt[Int].filter(_ >= 0).getOrElse(1)),
-        transport = (json \ "transport").asOpt(McpConnectorTransport.format).getOrElse(McpConnectorTransport()),
+        transport = (json \ "transport").asOpt(using McpConnectorTransport.format).getOrElse(McpConnectorTransport()),
         strict = (json \ "strict").asOpt[Boolean].getOrElse(true),
         includeFunctions = json.select("include_functions").asOpt[Seq[String]].getOrElse(Seq.empty),
         excludeFunctions = json.select("exclude_functions").asOpt[Seq[String]].getOrElse(Seq.empty),
@@ -821,8 +822,8 @@ object McpConnector {
         excludeResourceTemplateUris = json.select("exclude_resource_template_uris").asOpt[Seq[String]].getOrElse(Seq.empty),
         includePrompts = json.select("include_prompts").asOpt[Seq[String]].getOrElse(Seq.empty),
         excludePrompts = json.select("exclude_prompts").asOpt[Seq[String]].getOrElse(Seq.empty),
-        allowRules = json.select("allow_rules").asOpt(McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
-        disallowRules = json.select("disallow_rules").asOpt(McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
+        allowRules = json.select("allow_rules").asOpt(using McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
+        disallowRules = json.select("disallow_rules").asOpt(using McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
         forwardAuth = json.select("forward_auth").asOpt[Boolean].getOrElse(false),
         auditEvents = json.select("audit_events").asOpt[Boolean].getOrElse(false),
       )
@@ -846,7 +847,7 @@ object McpConnector {
         extractIdf = c => datastores.mcpConnectorsDatastore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           McpConnector(
             id = IdGenerator.namedId("mcp-connector", env),
             enabled = true,
@@ -890,7 +891,7 @@ class KvMcpConnectorsDataStore(extensionId: AdminExtensionId, redisCli: RedisLik
     with RedisLikeStore[McpConnector] {
   override def fmt: Format[McpConnector] = McpConnector.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:mcpconntr:$id"
 
@@ -898,75 +899,57 @@ class KvMcpConnectorsDataStore(extensionId: AdminExtensionId, redisCli: RedisLik
 }
 
 object McpSupportImplicits {
-  implicit class BetterJsonBooleanSchema(val node: JsonBooleanSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonBooleanSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonEnumSchema(val node: JsonEnumSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonEnumSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonIntegerSchema(val node: JsonIntegerSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonIntegerSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonNumberSchema(val node: JsonNumberSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonNumberSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonStringSchema(val node: JsonStringSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonStringSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonObjectSchema(val node: JsonObjectSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonObjectSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonAnyOfSchema(val node: JsonAnyOfSchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonAnyOfSchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterJsonArraySchema(val node: JsonArraySchema) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: JsonArraySchema) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 
-  implicit class BetterToolSpecification(val node: ToolSpecification) extends AnyVal {
-    def safeDescription(): String = {
-      Option(node.description()).getOrElse("")
-    }
+  extension (node: ToolSpecification) {
+    def safeDescription(): String = Option(node.description()).getOrElse("")
   }
 }
 
 object McpSupport {
 
-  import McpSupportImplicits._
+  import McpSupportImplicits.*
 
   private val gson = new Gson()
 
-  def restartConnectorsIfNeeded()(implicit env: Env): Unit = {
+  def restartConnectorsIfNeeded()(using env: Env): Unit = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ext.states.allMcpConnectors().foreach { connector =>
       connector.restartIfNeeded()
     }
   }
 
-  def stopConnectorsIfNeeded()(implicit env: Env): Unit = {
+  def stopConnectorsIfNeeded()(using env: Env): Unit = {
     val ext = env.adminExtensions.extension[AiExtension].get
     McpConnector.connectorsCache.keySet.foreach { key =>
       ext.states.mcpConnector(key) match {
@@ -1043,7 +1026,7 @@ object McpSupport {
   // NOTE: langchain4j never parses the MCP `outputSchema`, so it cannot be recovered through this path.
   def toolSpecToJson(desc: ToolSpecification): JsObject = {
     val required: Seq[String] = Option(desc.parameters()).flatMap(p => Option(p.required())).map(_.asScala.toSeq).getOrElse(Seq.empty)
-    val properties: JsObject = JsObject(Option(desc.parameters()).flatMap(p => Option(p.properties())).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues(schemaToJson).toMap)
+    val properties: JsObject = JsObject(Option(desc.parameters()).flatMap(p => Option(p.properties())).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
     val base = Json.obj(
       "name" -> desc.name(),
       "description" -> desc.description(),
@@ -1058,8 +1041,8 @@ object McpSupport {
     val annotations = ToolAnnotationKeys.toSeq.flatMap(k => md.get(k).map(v => k -> anyRefToJsValue(v))) ++
       md.get("title-annotation").map(v => "title" -> anyRefToJsValue(v)).toSeq
     val annotationsObj = if (annotations.nonEmpty) Json.obj("annotations" -> JsObject(annotations.toMap)) else Json.obj()
-    val metaEntries = md.filterKeys(k => !ToolMetaExcludedKeys.contains(k)).toMap
-    val metaObj = if (metaEntries.nonEmpty) Json.obj("_meta" -> JsObject(metaEntries.mapValues(anyRefToJsValue).toMap)) else Json.obj()
+    val metaEntries = md.view.filterKeys(k => !ToolMetaExcludedKeys.contains(k)).toMap
+    val metaObj = if (metaEntries.nonEmpty) Json.obj("_meta" -> JsObject(metaEntries.view.mapValues(anyRefToJsValue).toMap)) else Json.obj()
     base ++ titleObj ++ annotationsObj ++ metaObj
   }
 
@@ -1073,12 +1056,8 @@ object McpSupport {
       case s: JsonObjectSchema => {
         val additionalProperties: scala.Boolean = Option(s.additionalProperties()).map(_.booleanValue()).getOrElse(false)
         val required: Seq[String] = Option(s.required()).map(_.asScala.toSeq).getOrElse(Seq.empty)
-        val properties: JsObject = JsObject(Option(s.properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-          schemaToJson(el)
-        })
-        val definitions: JsObject = JsObject(Option(s.definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-          schemaToJson(el)
-        })
+        val properties: JsObject = JsObject(Option(s.properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
+        val definitions: JsObject = JsObject(Option(s.definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
         Json.obj(
           "description" -> s.safeDescription(),
           "type" -> "object",
@@ -1095,19 +1074,15 @@ object McpSupport {
     }
   }
 
-  def tools(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Seq[JsObject] = {
+  def tools(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(using env: Env, ec: ExecutionContext): Seq[JsObject] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     connectors.zipWithIndex.flatMap(tuple => ext.states.mcpConnector(tuple._1).map(v => (v, tuple._2))).flatMap {
       case (connector, idx) =>
         connector.copy(includeFunctions = connector.includeFunctions ++ includeFunctions, excludeFunctions = connector.excludeFunctions ++ excludeFunctions).listToolsBlocking(attrs).map { function =>
           val additionalProperties: scala.Boolean = Option(function.parameters().additionalProperties()).map(_.booleanValue()).getOrElse(false)
           val required: Seq[String] = Option(function.parameters().required()).map(_.asScala.toSeq).getOrElse(Seq.empty)
-          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
-          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
+          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
+          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
           Json.obj(
             "type" -> "function",
             "function" -> Json.obj(
@@ -1128,7 +1103,7 @@ object McpSupport {
     }
   }
 
-  def toolsCohere(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): (Seq[JsObject], Map[String, String]) = {
+  def toolsCohere(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(using env: Env, ec: ExecutionContext): (Seq[JsObject], Map[String, String]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val map = new TrieMap[String, String]()
     (connectors.zipWithIndex.flatMap(tuple => ext.states.mcpConnector(tuple._1).map(v => (v, tuple._2))).flatMap {
@@ -1136,12 +1111,8 @@ object McpSupport {
         connector.copy(includeFunctions = connector.includeFunctions ++ includeFunctions, excludeFunctions = connector.excludeFunctions ++ excludeFunctions).listToolsBlocking(attrs).map { function =>
           val additionalProperties: scala.Boolean = Option(function.parameters().additionalProperties()).map(_.booleanValue()).getOrElse(false)
           val required: Seq[String] = Option(function.parameters().required()).map(_.asScala.toSeq).getOrElse(Seq.empty)
-          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
-          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
+          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
+          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
           val fname = ("mcp___" + s"${idx}___${function.name()}".sha256)
           map.put(s"${idx}___${function.name()}".sha256, s"${idx}___${function.name()}")
           Json.obj(
@@ -1164,19 +1135,15 @@ object McpSupport {
     }, map.toMap)
   }
 
-  def toolsAnthropic(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Seq[JsObject] = {
+  def toolsAnthropic(connectors: Seq[String], includeFunctions: Seq[String], excludeFunctions: Seq[String], attrs: TypedMap)(using env: Env, ec: ExecutionContext): Seq[JsObject] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     connectors.zipWithIndex.flatMap(tuple => ext.states.mcpConnector(tuple._1).map(v => (v, tuple._2))).flatMap {
       case (connector, idx) =>
         connector.copy(includeFunctions = connector.includeFunctions ++ includeFunctions, excludeFunctions = connector.excludeFunctions ++ excludeFunctions).listToolsBlocking(attrs).map { function =>
           val additionalProperties: scala.Boolean = Option(function.parameters().additionalProperties()).map(_.booleanValue()).getOrElse(false)
           val required: Seq[String] = Option(function.parameters().required()).map(_.asScala.toSeq).getOrElse(Seq.empty)
-          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
-          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).mapValues { el =>
-            schemaToJson(el)
-          })
+          val properties: JsObject = JsObject(Option(function.parameters().properties()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
+          val definitions: JsObject = JsObject(Option(function.parameters().definitions()).map(_.asScala).getOrElse(Map.empty[String, JsonSchemaElement]).view.mapValues(schemaToJson).toMap)
           Json.obj(
             "name" -> s"mcp___${idx}___${function.name()}",
             "description" -> function.safeDescription(),
@@ -1192,7 +1159,7 @@ object McpSupport {
     }
   }
 
-  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callTool(functions, connectors, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool",
@@ -1206,7 +1173,7 @@ object McpSupport {
     }
   }
 
-  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, fmap: Map[String, String], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, fmap: Map[String, String], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callToolCohere(functions, connectors, fmap, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool",
@@ -1220,7 +1187,7 @@ object McpSupport {
     }
   }
 
-  private def callToolCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], fmap: Map[String, String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callToolCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], fmap: Map[String, String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { _toolCall =>
         val fn = _toolCall.raw.select("function").asObject
@@ -1247,10 +1214,10 @@ object McpSupport {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], connectors: Seq[String], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callAnthropic(functions, connectors, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> Json.arr(Json.obj(
@@ -1267,7 +1234,7 @@ object McpSupport {
     }
   }
 
-  private def callAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val args = toolCall.arguments
@@ -1291,10 +1258,10 @@ object McpSupport {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callTool(functions, connectors, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "content" -> "", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool",
@@ -1303,7 +1270,7 @@ object McpSupport {
     }
   }
 
-  private def callTool(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callTool(functions: Seq[GenericApiResponseChoiceMessageToolCall], connectors: Seq[String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val cid = toolCall.function.connectorId
@@ -1326,7 +1293,7 @@ object McpSupport {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 }
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/mcpvirtualserver.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/mcpvirtualserver.scala
@@ -6,10 +6,10 @@ import otoroshi.models.{EntityLocation, EntityLocationSupport}
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
 import otoroshi.storage.{BasicStore, RedisLike, RedisLikeStore}
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiGatewayExtensionDatastores, AiGatewayExtensionState}
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.McpProxyEndpointConfig
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.{Failure, Success, Try}
 
@@ -101,8 +101,8 @@ object McpVirtualServer {
         description = (json \ "description").asOpt[String].getOrElse(""),
         metadata = (json \ "metadata").asOpt[Map[String, String]].getOrElse(Map.empty),
         tags = (json \ "tags").asOpt[Seq[String]].getOrElse(Seq.empty[String]),
-        config = (json \ "config").asOpt(McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default),
-        registry = (json \ "registry").asOpt(McpRegistryConfig.format).getOrElse(McpRegistryConfig.empty),
+        config = (json \ "config").asOpt(using McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default),
+        registry = (json \ "registry").asOpt(using McpRegistryConfig.format).getOrElse(McpRegistryConfig.empty),
       )
     } match {
       case Failure(ex) => JsError(ex.getMessage)
@@ -124,7 +124,7 @@ object McpVirtualServer {
         extractIdf = c => datastores.mcpVirtualServersDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           McpVirtualServer(
             id = IdGenerator.namedId("mcp-virtual-server", env),
             enabled = true,
@@ -156,7 +156,7 @@ class KvMcpVirtualServersDataStore(extensionId: AdminExtensionId, redisCli: Redi
     with RedisLikeStore[McpVirtualServer] {
   override def fmt: Format[McpVirtualServer] = McpVirtualServer.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:mcpvirtsrv:$id"
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/memory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/memory.scala
@@ -1,16 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.PersistentMemoryClient
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import scala.util.{Failure, Success, Try}
 
@@ -30,7 +30,7 @@ case class PersistentMemory(
   override def theDescription: String           = description
   override def theTags: Seq[String]             = tags
   override def theMetadata: Map[String, String] = metadata
-  def getPersistentMemoryClient()(implicit env: Env): Option[PersistentMemoryClient] = {
+  def getPersistentMemoryClient()(using env: Env): Option[PersistentMemoryClient] = {
     provider.toLowerCase() match {
       case "local" => new LocalPersistentMemoryClient(config, id).some
       case "elasticsearch" | "elastic" => new ElasticsearchPersistentMemoryClient(config, id).some
@@ -84,7 +84,7 @@ object PersistentMemory {
         extractIdf = c => datastores.persistentMemoriesDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case _ => EmbeddingStore(
               id = IdGenerator.namedId("persistent-memory", env),
@@ -126,7 +126,7 @@ class KvPersistentMemoryDataStore(extensionId: AdminExtensionId, redisCli: Redis
   extends PersistentMemoryDataStore
     with RedisLikeStore[PersistentMemory] {
   override def fmt: Format[PersistentMemory]                  = PersistentMemory.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:persistentmems:$id"
   override def extractId(value: PersistentMemory): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/moderation.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/moderation.scala
@@ -1,17 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.ModerationModelClient
-import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{ImageModelClientDecorators, ModerationModelClientDecorators}
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.decorators.ModerationModelClientDecorators
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -42,7 +42,7 @@ case class ModerationModel(
 
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
 
-  def getModerationModelClient()(implicit env: Env): Option[ModerationModelClient] = {
+  def getModerationModelClient()(using env: Env): Option[ModerationModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val options = config.select("options").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
@@ -71,19 +71,19 @@ object ModerationModel {
   // provider here is the only change required.
   val clientBuilders: Map[String, ModerationModel.ClientContext => Option[ModerationModelClient]] = Map(
     "openai" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "OpenAI", env = env)
       val opts = OpenAiModerationModelClientOptions.fromJson(options)
       new OpenAiModerationModelClient(api, opts, id).some
     },
     "mistral" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new MistralAiApi(baseUrl.getOrElse(MistralAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = MistralAiModerationModelClientOptions.fromJson(options)
       new MistralAiModerationModelClient(api, opts, id).some
     },
     "openai-compatible" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // generic OpenAI-compatible moderation endpoint: base url, display name, headers and param
       // mappings are all driven by the connection config (dynamic name).
       val providerName = connection.select("provider_name").asOpt[String]
@@ -106,7 +106,7 @@ object ModerationModel {
       new OpenAiModerationModelClient(api, opts, id).some
     },
     "ovh-ai-endpoints" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       // OVH AI Endpoints moderation through their unified OpenAI-compatible API
       val api = new OpenAiApi(baseUrl.getOrElse(OVHAiEndpointsApi.unifiedUrl), token, timeout.getOrElse(3.minutes), providerName = "OVH", env = env)
       val opts = OpenAiModerationModelClientOptions.fromJson(options)
@@ -160,7 +160,7 @@ object ModerationModel {
         extractIdf = c => datastores.moderationModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("openai") => ModerationModel(
               id = IdGenerator.namedId("provider", env),
@@ -233,7 +233,7 @@ class KvModerationModelsDataStore(extensionId: AdminExtensionId, redisCli: Redis
     with RedisLikeStore[ModerationModel] {
   override def fmt: Format[ModerationModel] = ModerationModel.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:moderationmodels:$id"
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/ocr.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/ocr.scala
@@ -2,16 +2,16 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.OcrModelClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.OcrModelClientDecorators
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -42,7 +42,7 @@ case class OcrModel(
 
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
 
-  def getOcrModelClient()(implicit env: Env): Option[OcrModelClient] = {
+  def getOcrModelClient()(using env: Env): Option[OcrModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
     val _token = connection.select("token").asOpt[String].getOrElse("xxx")
@@ -70,12 +70,12 @@ object OcrModel {
   // `supportedProviders` (and the providers catalog) is derived from these keys.
   val clientBuilders: Map[String, OcrModel.ClientContext => Option[OcrModelClient]] = Map(
     "alphaedge" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new AlphaEdgeApi(baseUrl.getOrElse(AlphaEdgeApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       new AlphaEdgeOcrModelClient(api, AlphaEdgeOcrModelClientOptions.fromJson(options), id).some
     },
     "mistral" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new MistralAiApi(baseUrl.getOrElse(MistralAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       new MistralOcrModelClient(api, MistralOcrModelClientOptions.fromJson(options), id).some
     },
@@ -127,7 +127,7 @@ object OcrModel {
         extractIdf = c => datastores.ocrModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("mistral") => OcrModel(
               id = IdGenerator.namedId("ocr-model", env),
@@ -189,7 +189,7 @@ class KvOcrModelsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, _
     with RedisLikeStore[OcrModel] {
   override def fmt: Format[OcrModel] = OcrModel.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:ocrmodels:$id"
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/prompt.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/prompt.scala
@@ -6,9 +6,9 @@ import otoroshi.models.{EntityLocation, EntityLocationSupport}
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
 import otoroshi.storage.{BasicStore, RedisLike, RedisLikeStore}
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiGatewayExtensionDatastores, AiGatewayExtensionState}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.{Failure, Success, Try}
 
@@ -69,7 +69,7 @@ object Prompt {
         extractIdf = c => datastores.promptsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           Prompt(
             id = IdGenerator.namedId("prompt", env),
             name = "Prompt",
@@ -99,7 +99,7 @@ class KvPromptDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, _env
   extends PromptDataStore
     with RedisLikeStore[Prompt] {
   override def fmt: Format[Prompt]                  = Prompt.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:prompts:$id"
   override def extractId(value: Prompt): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/provider.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/provider.scala
@@ -2,20 +2,20 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{ChatClientDecorators, Guardrails, LoadBalancerChatClient, OtoroshiRouterChatClient}
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
 import otoroshi.api.{GenericResourceAccessApiWithState, Resource, ResourceVersion}
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiGatewayExtensionDatastores, AiGatewayExtensionState}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 
 case class RegexValidationSettings(
@@ -180,7 +180,7 @@ case class AiProvider(
   lazy val isOtoroshiAssistant: Boolean = metadata.get("otoroshi_assistant").contains("true")
   def computedName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name)
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
-  def getChatClient()(implicit env: Env): Option[ChatClient] = {
+  def getChatClient()(using env: Env): Option[ChatClient] = {
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
     val _token = connection.select("token").asOpt[String].getOrElse("xxx")
     val token = if (_token.contains(",")) {
@@ -209,13 +209,13 @@ object AiProvider {
   val chatClientBuilders: Map[String, AiProvider.ChatClientContext => Option[ChatClient]] = {
     val explicit: Map[String, AiProvider.ChatClientContext => Option[ChatClient]] = Map(
       "openai" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(OpenAiApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "OpenAI", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "openai").some
       },
       "openai-compatible" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val supportsCompletion = connection.select("supports_completion").asOptBoolean.getOrElse(true)
         val paramMappings = connection.select("param_mappings").asOpt[Map[String, String]].getOrElse(Map.empty)
         val customHeaders = connection.select("headers").asOpt[Map[String, String]].getOrElse(Map("Authorization" -> "Bearer {api_key}"))
@@ -245,31 +245,31 @@ object AiProvider {
         ).some
       },
       "cloud-temple" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(CloudTemple.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Cloud Temple", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "cloud-temple", accumulateStreamConsumptions = false).some
       },
       "scaleway" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(ScalewayApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Scaleway", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "scaleway", accumulateStreamConsumptions = false).some
       },
       "deepseek" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(DeepSeekApi.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Deepseek", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "deepseek", "/models").some
       },
       "x-ai" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new XAiApi(baseUrl.getOrElse(XAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
         val opts = XAiChatClientOptions.fromJson(options)
         new XAiChatClient(api, opts, id).some
       },
       "ovh-ai-endpoints" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val unified = connection.select("unified").asOpt[Boolean].getOrElse(true)
         if (unified) {
           val api = new OpenAiApi(OVHAiEndpointsApi.unifiedUrl, token, timeout.getOrElse(3.minutes), providerName = "OVH", env = env)
@@ -282,13 +282,13 @@ object AiProvider {
         }
       },
       "ovh-ai-endpoints-unified" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(OVHAiEndpointsApi.unifiedUrl), token, timeout.getOrElse(3.minutes), providerName = "OVH", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "OVH", "/models").some
       },
       "azure-openai" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val resourceName = connection.select("resource_name").as[String]
         val deploymentId = connection.select("deployment_id").as[String]
         val version = connection.select("api_version").asOpt[String].getOrElse("2024-02-01")
@@ -299,13 +299,13 @@ object AiProvider {
         new AzureOpenAiChatClient(api, opts, id).some
       },
       "azure-ai-foundry" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(AzureAiFoundry.baseUrl), token, timeout.getOrElse(3.minutes), providerName = "Azure AI Foundry", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "azure-ai-foundry", "/models").some
       },
       "cloudflare" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val accountId = connection.select("account_id").as[String]
         val modelName = connection.select("model_name").as[String]
         val api = new CloudflareApi(accountId, modelName, token, timeout.getOrElse(3.minutes), env = env)
@@ -313,7 +313,7 @@ object AiProvider {
         new CloudflareChatClient(api, opts, id).some
       },
       "gemini" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         //-------
         //val model = connection.select("model").asOpt[String].getOrElse("gemini-1.5-flash")
         //val api = new GeminiApi(model, token, timeout.getOrElse(3.minutes), env = env)
@@ -325,7 +325,7 @@ object AiProvider {
         new OpenAiChatClient(api, opts, id, "gemini", "/models", completion = false, accumulateStreamConsumptions = false).some
       },
       "huggingface" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         // val modelName = connection.select("model_name").as[String]
         // val api = new HuggingfaceApi(modelName, token, timeout.getOrElse(3.minutes), env)
         // val opts = HuggingfaceChatClientOptions.fromJson(options)
@@ -335,38 +335,38 @@ object AiProvider {
         new OpenAiChatClient(api, opts, id, "huggingface", "/models", completion = false).some
       },
       "mistral" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new MistralAiApi(baseUrl.getOrElse(MistralAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
         val opts = MistralAiChatClientOptions.fromJson(options)
         new MistralAiChatClient(api, opts, id).some
       },
       "alphaedge" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         // OCR-only provider: the chat call requires a file (image/pdf) content part and returns the extracted text
         val api = new AlphaEdgeApi(baseUrl.getOrElse(AlphaEdgeApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
         val opts = AlphaEdgeChatClientOptions.fromJson(options)
         new AlphaEdgeChatClient(api, opts, id).some
       },
       "ollama" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OllamaAiApi(baseUrl.getOrElse(OllamaAiApi.baseUrl), token.some.filterNot(_ == "xxx"), timeout.getOrElse(3.minutes), env = env)
         val opts = OllamaAiChatClientOptions.fromJson(options)
         new OllamaAiChatClient(api, opts, id).some
       },
       "ollama-openai" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new OpenAiApi(baseUrl.getOrElse(OllamaAiApi.baseUrlOAI), token, timeout.getOrElse(3.minutes), providerName = "Ollama (OAI compat)", env = env)
         val opts = OpenAiChatClientOptions.fromJson(options)
         new OpenAiChatClient(api, opts, id, "ollama").some
       },
       "cohere" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new CohereAiApi(baseUrl.getOrElse(CohereAiApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
         val opts = CohereAiChatClientOptions.fromJson(options)
         new CohereAiChatClient(api, opts, id).some
       },
       "anthropic" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val version = connection.select("version").asOpt[String].getOrElse("2023-06-01")
         val beta = connection.select("beta").asOpt[String]
         val api = new AnthropicApi(baseUrl.getOrElse(AnthropicApi.baseUrl), token, version, beta, timeout.getOrElse(3.minutes), env = env)
@@ -374,13 +374,13 @@ object AiProvider {
         new AnthropicChatClient(api, opts, id).some
       },
       "groq" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val api = new GroqApi(baseUrl.getOrElse(GroqApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
         val opts = GroqChatClientOptions.fromJson(options)
         new GroqChatClient(api, opts, id).some
       },
       "jlama" -> { (c: ChatClientContext) =>
-        import c._
+        import c.*
         val opts = JlamaChatClientOptions.fromJson(options)
         new JlamaChatClient(opts, id).some
       },
@@ -390,7 +390,7 @@ object AiProvider {
     val likes: Map[String, AiProvider.ChatClientContext => Option[ChatClient]] =
       OpenAiLikeProviders.all.map { provDef =>
         provDef.id -> { (c: ChatClientContext) =>
-          import c._
+          import c.*
           val api = new OpenAiApi(
             _baseUrl = baseUrl.getOrElse(provDef.baseUrl),
             token = token,
@@ -478,7 +478,7 @@ object AiProvider {
         extractIdf = c => datastores.providersDatastore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("provider").map(_.toLowerCase()) match {
             case Some("openai") => AiProvider(
               id = IdGenerator.namedId("provider", env),
@@ -639,7 +639,7 @@ class KvAiProviderDataStore(extensionId: AdminExtensionId, redisCli: RedisLike, 
   extends AiProviderDataStore
     with RedisLikeStore[AiProvider] {
   override def fmt: Format[AiProvider]                  = AiProvider.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:providers:$id"
   override def extractId(value: AiProvider): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/search.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/search.scala
@@ -1,18 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import com.cloud.apim.otoroshi.extensions.aigateway.{SearchEngineClient, SearchEngineSearchOptions}
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
+import otoroshi.storage.*
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -43,7 +43,7 @@ case class SearchEngine(
 
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
 
-  def getSearchEngineClient()(implicit env: Env): Option[SearchEngineClient] = {
+  def getSearchEngineClient()(using env: Env): Option[SearchEngineClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
     val _token = connection.select("token").asOpt[String].getOrElse("xxx")
@@ -184,7 +184,7 @@ object SearchEngine {
         extractIdf = c => datastores.searchEnginesDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => SearchEngine.template(p.get("kind").map(_.toLowerCase()).getOrElse("staan"), env).json,
+        tmpl = (_, p, _) => SearchEngine.template(p.get("kind").map(_.toLowerCase()).getOrElse("staan"), env).json,
         canRead = true,
         canCreate = true,
         canUpdate = true,
@@ -232,22 +232,22 @@ object SearchEngineSupport {
     }
   }
 
-  def tools(engines: Seq[String])(implicit env: Env): Seq[JsObject] = {
+  def tools(engines: Seq[String])(using env: Env): Seq[JsObject] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     engines.flatMap(ext.states.searchEngine).map(se => decl(se, anthropic = false))
   }
 
-  def toolsAnthropic(engines: Seq[String])(implicit env: Env): Seq[JsObject] = {
+  def toolsAnthropic(engines: Seq[String])(using env: Env): Seq[JsObject] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     engines.flatMap(ext.states.searchEngine).map(se => decl(se, anthropic = true))
   }
 
   // engine ids are id-safe so no name hashing is needed (unlike mcp/wasm); returns an empty name map.
-  def toolsCohere(engines: Seq[String])(implicit env: Env): (Seq[JsObject], Map[String, String]) = {
+  def toolsCohere(engines: Seq[String])(using env: Env): (Seq[JsObject], Map[String, String]) = {
     (tools(engines), Map.empty[String, String])
   }
 
-  private def executeSearch(engineId: String, argsJson: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  private def executeSearch(engineId: String, argsJson: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ext.states.searchEngine(engineId).flatMap(_.getSearchEngineClient()) match {
       case None => s"unknown or unavailable search engine: ${engineId}".vfuture
@@ -262,25 +262,25 @@ object SearchEngineSupport {
     }
   }
 
-  private def runGeneric(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def runGeneric(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         executeSearch(toolCall.function.searchEngineId, toolCall.function.arguments, attrs).map(r => (r, toolCall))
       }
       .flatMapConcat { case (resp, tc) => f(resp, tc) }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def runAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def runAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         executeSearch(toolCall.searchEngineId, toolCall.arguments, attrs).map(r => (r, toolCall))
       }
       .flatMapConcat { case (resp, tc) => f(resp, tc) }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     runGeneric(functions, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool",
@@ -292,7 +292,7 @@ object SearchEngineSupport {
     }
   }
 
-  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     runGeneric(functions, attrs) { (resp, tc) =>
       Source(List(Json.obj("role" -> "assistant", "content" -> "", "tool_calls" -> Json.arr(tc.raw)), Json.obj(
         "role" -> "tool",
@@ -301,11 +301,11 @@ object SearchEngineSupport {
     }
   }
 
-  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callToolsOpenai(functions, providerName, attrs)
   }
 
-  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     runAnthropic(functions, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> Json.arr(Json.obj(
@@ -330,7 +330,7 @@ class KvSearchEnginesDataStore(extensionId: AdminExtensionId, redisCli: RedisLik
     with RedisLikeStore[SearchEngine] {
   override def fmt: Format[SearchEngine] = SearchEngine.format
 
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
 
   override def key(id: String): String = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:searchengines:$id"
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/template.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/template.scala
@@ -2,13 +2,13 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import otoroshi.api.{GenericResourceAccessApiWithState, Resource, ResourceVersion}
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.{AiGatewayExtensionDatastores, AiGatewayExtensionState}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.{Failure, Success, Try}
 
@@ -68,7 +68,7 @@ object PromptTemplate {
         extractIdf = c => datastores.promptTemplatesDatastore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           PromptTemplate(
             id = IdGenerator.namedId("prompt-template", env),
             name = "Prompt template",
@@ -98,7 +98,7 @@ class KvPromptTemplateDataStore(extensionId: AdminExtensionId, redisCli: RedisLi
   extends PromptTemplateDataStore
     with RedisLikeStore[PromptTemplate] {
   override def fmt: Format[PromptTemplate]                  = PromptTemplate.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:templates:$id"
   override def extractId(value: PromptTemplate): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/toolfunction.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/toolfunction.scala
@@ -1,30 +1,30 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
-import akka.stream.alpakka.s3._
-import akka.stream.alpakka.s3.scaladsl.S3
-import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{Attributes, Materializer}
-import akka.util.ByteString
+import org.apache.pekko.stream.connectors.s3.*
+import org.apache.pekko.stream.connectors.s3.scaladsl.S3
+import org.apache.pekko.stream.scaladsl.{Keep, Sink, Source}
+import org.apache.pekko.stream.{Attributes, Materializer}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.agents.InlineFunctions
 import com.github.blemale.scaffeine.Scaffeine
 import io.otoroshi.wasm4s.scaladsl.{WasmFunctionParameters, WasmSource, WasmSourceKind}
-import otoroshi.api._
+import otoroshi.api.*
 import otoroshi.el.GlobalExpressionLanguage
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.next.models.NgTlsConfig
 import otoroshi.next.plugins.BodyHelper
-import otoroshi.next.workflow.{Node, WorkflowAdminExtension, WorkflowHelper}
+import otoroshi.next.workflow.{Node, WorkflowAdminExtension}
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
+import otoroshi.storage.*
 import otoroshi.storage.drivers.inmemory.S3Configuration
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi.wasm.{WasmAuthorizations, WasmConfig}
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers.AwsRegionProvider
@@ -35,6 +35,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{DurationInt, DurationLong}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+import play.api.libs.ws.WSBodyWritables.given
 
 sealed trait LlmToolFunctionBackendKind {
   def name: String
@@ -66,7 +67,7 @@ case class LlmToolFunctionBackend(kind: LlmToolFunctionBackendKind, options: Llm
 
 sealed trait LlmToolFunctionBackendOptions {
   def json: JsValue
-  def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String]
+  def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String]
 }
 
 object LlmToolFunctionBackendOptions {
@@ -86,25 +87,22 @@ object LlmToolFunctionBackendOptions {
     S3Attributes.settings(settings)
   }
 
-  private def fileContent(key: String, config: S3Configuration)(implicit
+  private def fileContent(key: String, config: S3Configuration)(using
                                                                 ec: ExecutionContext,
                                                                 mat: Materializer
   ): Future[Option[(ObjectMetadata, ByteString)]] = {
-    S3.download(config.bucket, key)
+    // S3.download is deprecated in pekko-connectors: getObject streams the bytes and
+    // materializes the metadata, and signals a missing object with a NoSuchKey S3Exception
+    // instead of an empty Option
+    val (metadataF, contentF) = S3
+      .getObject(config.bucket, key)
       .withAttributes(s3ClientSettingsAttrs(config))
-      .runWith(Sink.headOption)
-      .map(_.flatten)
-      .flatMap { opt =>
-        opt
-          .map {
-            case (source, om) => {
-              source.runFold(ByteString.empty)(_ ++ _).map { content =>
-                (om, content).some
-              }
-            }
-          }
-          .getOrElse(None.vfuture)
-      }
+      .toMat(Sink.fold(ByteString.empty)(_ ++ _))(Keep.both)
+      .run()
+    metadataF
+      .zip(contentF)
+      .map(_.some)
+      .recover { case e: S3Exception if e.code == "NoSuchKey" => None }
   }
 
   def getDefaultToolCallCode(): Future[String] = {
@@ -116,7 +114,7 @@ object LlmToolFunctionBackendOptions {
        |""".stripMargin.vfuture
   }
 
-  def getCode(path: String, headers: Map[String, String], defaultCode: () => Future[String])(implicit env: Env, ec: ExecutionContext): Future[String] = {
+  def getCode(path: String, headers: Map[String, String], defaultCode: () => Future[String])(using env: Env, ec: ExecutionContext): Future[String] = {
 
     LlmToolFunction.modulesCache.getIfPresent(path) match {
       case Some(code) => code.vfuture
@@ -125,12 +123,12 @@ object LlmToolFunctionBackendOptions {
           env.Ws.url(path)
             .withFollowRedirects(true)
             .withRequestTimeout(30.seconds)
-            .withHttpHeaders(headers.toSeq: _*)
+            .withHttpHeaders(headers.toSeq*)
             .get()
             .flatMap { response =>
               if (response.status == 200) {
                 LlmToolFunction.modulesCache.put(path, response.body)
-                response.body.vfuture
+                (response.body: String).vfuture
               } else {
                 defaultCode().map { code =>
                   LlmToolFunction.modulesCache.put(path, code)
@@ -155,8 +153,8 @@ object LlmToolFunctionBackendOptions {
           path.vfuture
         } else if (path.startsWith("s3://")) {
           LlmToolFunction.logger.info(s"fetching from S3: ${path}")
-          val config = S3Configuration.format.reads(JsObject(headers.mapValues(_.json))).get
-          fileContent(path.replaceFirst("s3://", ""), config)(env.otoroshiExecutionContext, env.otoroshiMaterializer).flatMap {
+          val config = S3Configuration.format.reads(JsObject(headers.view.mapValues(_.json).toMap)).get
+          fileContent(path.replaceFirst("s3://", ""), config)(using env.otoroshiExecutionContext, env.otoroshiMaterializer).flatMap {
             case None => {
               LlmToolFunction.logger.info(s"unable to fetch from S3: ${path}")
               defaultCode().map { code =>
@@ -202,14 +200,14 @@ object LlmToolFunctionBackendOptions {
       "jsPath" -> jsPath
     )
 
-    def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+    def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
       jsPath match {
         case None => "error, not wasm plugin ref".vfuture
         case Some(path) => {
           getCode(path, Map.empty, LlmToolFunctionBackendOptions.getDefaultToolCallCode).flatMap { code =>
             env.wasmIntegration.wasmVmFor(LlmToolFunction.wasmConfigRef).flatMap {
               case None => "unable to create wasm vm".vfuture
-              case Some((vm, localconfig)) => {
+              case Some((vm, _)) => {
                 vm.call(
                   WasmFunctionParameters.ExtismFuntionCall(
                     "cloud_apim_module_plugin_execute_tool_call",
@@ -246,7 +244,7 @@ object LlmToolFunctionBackendOptions {
       "wasmPlugin" -> wasmPlugin
     )
 
-    def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+    def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
       wasmPlugin match {
         case None => "error, not wasm plugin ref".vfuture
         case Some(ref) => {
@@ -281,7 +279,7 @@ object LlmToolFunctionBackendOptions {
 
     def json: JsValue = options
 
-    def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+    def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
 
       def replace(str: String, params: Map[String, String]): String = {
         if (str.contains("${")) {
@@ -324,7 +322,7 @@ object LlmToolFunctionBackendOptions {
       env.MtlsWs
         .url(url, tlsConfig.legacy)
         .withMethod(method)
-        .withHttpHeaders(headers.toSeq: _*)
+        .withHttpHeaders(headers.toSeq*)
         .withRequestTimeout(timeout.millis)
         .withFollowRedirects(followRedirect)
         .applyOnWithOpt(body) {
@@ -348,7 +346,7 @@ object LlmToolFunctionBackendOptions {
 
   case class Route(options: JsValue) extends LlmToolFunctionBackendOptions {
     def json: JsValue = options
-    def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = Future.apply("Route backend not supported yet")
+    def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = Future.apply("Route backend not supported yet")
   }
 
   case class Workflow(options: JsValue, root: JsValue) extends LlmToolFunctionBackendOptions {
@@ -359,7 +357,7 @@ object LlmToolFunctionBackendOptions {
       "workflow_id" -> workflow_id
     )
 
-    def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+    def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
       workflow_id match {
         case None => "error, no workflow ref".vfuture
         case Some(ref) => {
@@ -419,7 +417,7 @@ case class LlmToolFunction(
 
   def toolId: String = name // was id, but could be problematic when using very long ids
 
-  //def callWasmPlugin(ref: String, arguments: String)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  //def callWasmPlugin(ref: String, arguments: String)(using ec: ExecutionContext, env: Env): Future[String] = {
   //  env.proxyState.wasmPlugin(ref) match {
   //    case None => "error, wasm plugin not found".vfuture
   //    case Some(plugin) => {
@@ -444,7 +442,7 @@ case class LlmToolFunction(
   //  }
   //}
 
-  //def callJsPlugin(path: String, arguments: String)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  //def callJsPlugin(path: String, arguments: String)(using ec: ExecutionContext, env: Env): Future[String] = {
   //  getCode(path, Map.empty).flatMap { code =>
   //    env.wasmIntegration.wasmVmFor(LlmToolFunction.wasmConfigRef).flatMap {
   //      case None => "unable to create wasm vm".vfuture
@@ -474,7 +472,7 @@ case class LlmToolFunction(
   //  }
   //}
 
-  def call(arguments: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[String] = {
+  def call(arguments: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[String] = {
     backend.kind match {
       case LlmToolFunctionBackendKind.QuickJs => backend.options.call(arguments, attrs)
       case LlmToolFunctionBackendKind.WasmPlugin => backend.options.call(arguments, attrs)
@@ -553,12 +551,12 @@ object LlmToolFunction {
     instances = 4
   )
 
-  val modulesCache = Scaffeine().maximumSize(1000).expireAfterWrite(120.seconds).build[String, String]
+  val modulesCache = Scaffeine().maximumSize(1000).expireAfterWrite(120.seconds).build[String, String]()
   val logger = Logger("LlmToolFunction")
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def _tools(functions: Seq[String])(implicit env: Env): Seq[JsObject] = {
+  def _tools(functions: Seq[String])(using env: Env): Seq[JsObject] = {
     /*Json.obj(
       "tools" -> JsArray(*/functions.flatMap(id => env.adminExtensions.extension[AiExtension].flatMap(ext => ext.states.toolFunction(id))).map { function =>
       val required: JsArray = function.required.map(v => JsArray(v.map(_.json))).getOrElse(JsArray(function.parameters.value.keySet.toSeq.map(_.json)))
@@ -580,7 +578,7 @@ object LlmToolFunction {
     )*/
   }
 
-  def _inlineTools(functions: Seq[String], attrs: TypedMap)(implicit env: Env): Seq[JsObject] = {
+  def _inlineTools(functions: Seq[String], attrs: TypedMap)(using env: Env): Seq[JsObject] = {
     attrs.get(InlineFunctions.InlineFunctionsKey) match {
       case None => Seq.empty
       case Some(inlineFunctions) => functions.flatMap(key => inlineFunctions.get(key)).map { function =>
@@ -605,7 +603,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def toolsCohere(functions: Seq[String])(implicit env: Env): (Seq[JsObject], Map[String, String]) = {
+  def toolsCohere(functions: Seq[String])(using env: Env): (Seq[JsObject], Map[String, String]) = {
     val map = new TrieMap[String, String]()
     (functions.flatMap(id => env.adminExtensions.extension[AiExtension].flatMap(ext => ext.states.toolFunction(id))).map { function =>
       val required: JsArray = function.required.map(v => JsArray(v.map(_.json))).getOrElse(JsArray(function.parameters.value.keySet.toSeq.map(_.json)))
@@ -628,7 +626,7 @@ object LlmToolFunction {
     }, map.toMap)
   }
 
-  def inlineToolsCohere(functions: Seq[String], attrs: TypedMap)(implicit env: Env): (Seq[JsObject], Map[String, String]) = {
+  def inlineToolsCohere(functions: Seq[String], attrs: TypedMap)(using env: Env): (Seq[JsObject], Map[String, String]) = {
     val map = new TrieMap[String, String]()
     (attrs.get(InlineFunctions.InlineFunctionsKey) match {
       case None => Seq.empty
@@ -656,7 +654,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def _toolsAnthropic(functions: Seq[String])(implicit env: Env): Seq[JsObject] = {
+  def _toolsAnthropic(functions: Seq[String])(using env: Env): Seq[JsObject] = {
     functions.flatMap(id => env.adminExtensions.extension[AiExtension].flatMap(ext => ext.states.toolFunction(id))).map { function =>
       val required: JsArray = function.required.map(v => JsArray(v.map(_.json))).getOrElse(JsArray(function.parameters.value.keySet.toSeq.map(_.json)))
       Json.obj(
@@ -672,7 +670,7 @@ object LlmToolFunction {
     }
   }
 
-  def _inlineToolsAnthropic(functions: Seq[String], attrs: TypedMap)(implicit env: Env): Seq[JsObject] = {
+  def _inlineToolsAnthropic(functions: Seq[String], attrs: TypedMap)(using env: Env): Seq[JsObject] = {
     attrs.get(InlineFunctions.InlineFunctionsKey) match {
       case None => Seq.empty
       case Some(inlineFunctions) => functions.flatMap(key => inlineFunctions.get(key)).map { function =>
@@ -693,7 +691,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private def callInline(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callInline(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.function.name.stripPrefix("wasm___")
@@ -713,10 +711,10 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def call(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def call(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.function.name
@@ -737,12 +735,12 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private def callCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.function.name
@@ -763,10 +761,10 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def callInlineCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callInlineCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], fmap: Map[String, String], attrs: TypedMap)(f: (String, GenericApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.function.name.stripPrefix("wasm___")
@@ -786,12 +784,12 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private def callAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.name
@@ -813,10 +811,10 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
-  private def callInlineAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, _])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  private def callInlineAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], attrs: TypedMap)(f: (String, AnthropicApiResponseChoiceMessageToolCall) => Source[JsValue, ?])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     Source(functions.toList)
       .mapAsync(1) { toolCall =>
         val fid = toolCall.name.stripPrefix("wasm___")
@@ -836,12 +834,12 @@ object LlmToolFunction {
       .flatMapConcat {
         case (resp, tc) => f(resp, tc)
       }
-      .runWith(Sink.seq)(env.otoroshiMaterializer)
+      .runWith(Sink.seq)(using env.otoroshiMaterializer)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def _callInlineToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callInlineToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callInline(functions, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)),
@@ -857,7 +855,7 @@ object LlmToolFunction {
     }
   }
 
-  def _callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callToolsOpenai(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     call(functions, attrs, nameToFunction) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)),
@@ -875,7 +873,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, fmap: Map[String, String], attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callCohere(functions, fmap, attrs, nameToFunction) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)),
@@ -891,7 +889,7 @@ object LlmToolFunction {
     }
   }
 
-  def callInlineToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, fmap: Map[String, String], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def callInlineToolsCohere(functions: Seq[GenericApiResponseChoiceMessageToolCall], providerName: String, fmap: Map[String, String], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callInlineCohere(functions, fmap, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "tool_calls" -> Json.arr(tc.raw)),
@@ -909,7 +907,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def _callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callAnthropic(functions, attrs, nameToFunction) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> Json.arr(Json.obj(
@@ -927,7 +925,7 @@ object LlmToolFunction {
     }
   }
 
-  def _callInlineToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callInlineToolsAnthropic(functions: Seq[AnthropicApiResponseChoiceMessageToolCall], providerName: String, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callInlineAnthropic(functions, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> Json.arr(Json.obj(
@@ -947,7 +945,7 @@ object LlmToolFunction {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def _callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap, nameToFunction: Map[String, String])(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     call(functions, attrs, nameToFunction) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> "", "tool_calls" -> Json.arr(tc.raw)),
@@ -958,7 +956,7 @@ object LlmToolFunction {
     }
   }
 
-  def _callInlineToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
+  def _callInlineToolsOllama(functions: Seq[GenericApiResponseChoiceMessageToolCall], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Seq[JsValue]] = {
     callInline(functions, attrs) { (resp, tc) =>
       Source(List(
         Json.obj("role" -> "assistant", "content" -> "", "tool_calls" -> Json.arr(tc.raw)),
@@ -1033,7 +1031,7 @@ object LlmToolFunction {
         extractIdf = c => datastores.toolFunctionDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, _, _) => {
           LlmToolFunction(
             id = IdGenerator.namedId("tool-function", env),
             name = "tool function",
@@ -1069,7 +1067,7 @@ class KvLlmToolFunctionDataStore(extensionId: AdminExtensionId, redisCli: RedisL
   extends LlmToolFunctionDataStore
     with RedisLikeStore[LlmToolFunction] {
   override def fmt: Format[LlmToolFunction]                  = LlmToolFunction.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:toolfunctions:$id"
   override def extractId(value: LlmToolFunction): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/video.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/entities/video.scala
@@ -2,16 +2,16 @@ package com.cloud.apim.otoroshi.extensions.aigateway.entities
 
 import com.cloud.apim.otoroshi.extensions.aigateway.VideoModelClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.VideosGenModelClientDecorators
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
-import otoroshi.api._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
+import otoroshi.api.*
 import otoroshi.env.Env
-import otoroshi.models._
+import otoroshi.models.*
 import otoroshi.next.extensions.AdminExtensionId
 import otoroshi.security.IdGenerator
-import otoroshi.storage._
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.storage.*
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -35,7 +35,7 @@ case class VideoModel(
   override def theTags: Seq[String]             = tags
   override def theMetadata: Map[String, String] = metadata
   def slugName: String = metadata.get("endpoint_name").orElse(metadata.get("provider_name")).getOrElse(name).slugifyWithSlash.replaceAll("-+", "_")
-  def getVideoModelClient()(implicit env: Env): Option[VideoModelClient] = {
+  def getVideoModelClient()(using env: Env): Option[VideoModelClient] = {
     val connection = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
     val options = config.select("options").asOpt[JsObject].getOrElse(Json.obj())
     val baseUrl = connection.select("base_url").orElse(connection.select("base_domain")).asOpt[String]
@@ -63,13 +63,13 @@ object VideoModel {
   // `supportedProviders` (and the providers catalog) is derived from these keys.
   val clientBuilders: Map[String, VideoModel.ClientContext => Option[VideoModelClient]] = Map(
     "luma" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new LumaApi(baseUrl.getOrElse(LumaApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = LumaVideoModelClientOptions.fromJson(options)
       new LumaVideoModelClient(api, opts, id).some
     },
     "openrouter" -> { (c: ClientContext) =>
-      import c._
+      import c.*
       val api = new OpenRouterApi(baseUrl.getOrElse(OpenRouterApi.baseUrl), token, timeout.getOrElse(3.minutes), env = env)
       val opts = OpenRouterVideoModelClientOptions.fromJson(options)
       new OpenRouterVideoModelClient(api, opts, id).some
@@ -120,7 +120,7 @@ object VideoModel {
         extractIdf = c => datastores.videoModelsDataStore.extractId(c),
         extractIdJsonf = json => json.select("id").asString,
         idFieldNamef = () => "id",
-        tmpl = (v, p, ctx) => {
+        tmpl = (_, p, _) => {
           p.get("kind").map(_.toLowerCase()) match {
             case Some("luma") => VideoModel(
               id = IdGenerator.namedId("video-model", env),
@@ -172,7 +172,7 @@ class KvVideoModelsDataStore(extensionId: AdminExtensionId, redisCli: RedisLike,
   extends VideoModelsDataStore
     with RedisLikeStore[VideoModel] {
   override def fmt: Format[VideoModel]                  = VideoModel.format
-  override def redisLike(implicit env: Env): RedisLike = redisCli
+  override def redisLike(using env: Env): RedisLike = redisCli
   override def key(id: String): String                 = s"${_env.storageRoot}:extensions:${extensionId.cleanup}:videomodels:$id"
   override def extractId(value: VideoModel): String    = value.id
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/extension.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/extension.scala
@@ -1,27 +1,29 @@
 package otoroshi_plugins.com.cloud.apim.extensions.aigateway
 
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.OtoroshiAssistant
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{CostsTracking, CostsTrackingSettings, LLMImpacts, LLMImpactsSettings}
-import com.cloud.apim.otoroshi.extensions.aigateway.entities._
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.*
 import com.cloud.apim.otoroshi.extensions.aigateway.guardrails.LLMGuardrailsHardcodedItems
-import com.cloud.apim.otoroshi.extensions.aigateway.providers._
+import com.cloud.apim.otoroshi.extensions.aigateway.providers.*
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt, InputChatMessage, KreuzbergHelper, WorkflowFunctionsInitializer}
 import com.github.blemale.scaffeine.Scaffeine
 import otoroshi.env.Env
-import otoroshi.models._
-import otoroshi.next.extensions.{AdminExtensionAdminApiRoute, _}
+import otoroshi.models.*
+import otoroshi.next.extensions.*
 import otoroshi.utils.TypedMap
 import otoroshi.utils.cache.types.UnboundedTrieMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{AiLlmProxy, ProofOfWorkPlugin}
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{RequestHeader, Result, Results}
 import play.api.{Configuration, Logger}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.ExecutionContext
+import org.apache.pekko.stream.Materializer
 
 class AiGatewayExtensionDatastores(env: Env, extensionId: AdminExtensionId) {
   val providersDatastore: AiProviderDataStore = new KvAiProviderDataStore(extensionId, env.datastores.redis, env)
@@ -255,8 +257,8 @@ class AiExtension(val env: Env) extends AdminExtension {
     logger.info("the 'AI - LLM Extension' is enabled !")
     JlamaChatClient.computeCanExecuteJlama(logger.some)
     KreuzbergHelper.computeCanExecuteKreuzberg(logger.some)
-    implicit val ev = env
-    implicit val ec = env.otoroshiExecutionContext
+    given ev: Env = env
+    given ec: ExecutionContext = env.otoroshiExecutionContext
     WorkflowFunctionsInitializer.initDefaults()
     AiBudgetClusterAgent.start(env, this)
     env.datastores.wasmPluginsDataStore.findById(LlmToolFunction.wasmPluginId).flatMap {
@@ -284,8 +286,8 @@ class AiExtension(val env: Env) extends AdminExtension {
   )
 
   def getResourceCode(path: String): String = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
     env.environment.resourceAsStream(path)
       .map(stream => StreamConverters.fromInputStream(() => stream).runFold(ByteString.empty)(_ ++ _).awaitf(10.seconds).utf8String)
       .getOrElse(s"'resource ${path} not found !'")
@@ -314,10 +316,10 @@ class AiExtension(val env: Env) extends AdminExtension {
   lazy val workflowNodeSwitchFile = getResourceCode("cloudapim/extensions/ai/WorkflowNodes.js")
   lazy val imgCode = getResourceCode("cloudapim/extensions/ai/undraw_visionary_technology_re_jfp7.svg")
 
-  def handleProviderTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleProviderTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -366,10 +368,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleContextTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleContextTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -412,10 +414,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleTemplateTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleTemplateTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -453,10 +455,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handlePromptTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handlePromptTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -488,10 +490,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleFunctionTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleFunctionTest(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -499,7 +501,7 @@ class AiExtension(val env: Env) extends AdminExtension {
         bodyJson.select("function").asOpt[JsObject] match {
           case None => Results.Ok(Json.obj("done" -> false, "error" -> "no provider")).vfuture
           case Some(function) => LlmToolFunction.format.reads(function) match {
-            case JsError(err) => Results.Ok(Json.obj("done" -> false, "error" -> "bad function format")).vfuture
+            case JsError(_) => Results.Ok(Json.obj("done" -> false, "error" -> "bad function format")).vfuture
             case JsSuccess(function, _) => {
               val params = bodyJson.select("parameters").asOptString.getOrElse("")
               function.call(params, TypedMap.empty).map { res =>
@@ -518,10 +520,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleGenAudioVoicesFetch(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleGenAudioVoicesFetch(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -535,8 +537,6 @@ class AiExtension(val env: Env) extends AdminExtension {
               AudioModel.format.reads(edited) match {
                 case JsError(errors) => Results.Ok(Json.obj("done" -> false, "error" -> "bad provider format")).vfuture
                 case JsSuccess(audioModel, _) => {
-                  val token = audioModel.config.select("token").asOptString.getOrElse("--")
-                  val key = s"${audioModel.id}-${token}".sha256
                   val forceUpdate: Boolean = req.getQueryString("force").contains("true")
                   if (forceUpdate) {
                     logger.info(s"forcing models reload for ${audioModel.name} / ${audioModel.id}")
@@ -566,10 +566,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleProviderModelsFetch(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleProviderModelsFetch(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -620,14 +620,14 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleJlamaStatus(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
+  def handleJlamaStatus(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
     Results.Ok(Json.obj("can_execute" -> JlamaChatClient.canExecuteJlama, "msg" -> JlamaChatClient.errorMsg)).vfuture
   }
 
   // Registry UI assistant: lists the routes that expose a given MCP virtual server, with a derived public URL
   // and detected auth, so the admin can fill `registry.url` (and validate OAuth/apikey/mTLS).
-  def handleMcpExpositionRoutesScan(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ev = env
+  def handleMcpExpositionRoutesScan(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ev: Env = env
     req.getQueryString("server") match {
       case None => Results.BadRequest(Json.obj("error" -> "missing 'server' query param")).vfuture
       case Some(vsId) =>
@@ -636,9 +636,9 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleRemainingBudget(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val ev = env
+  def handleRemainingBudget(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     req.getQueryString("budget") match {
       case None => Results.NotFound(Json.obj("error" -> "no budget found")).vfuture
       case Some(budgetId) => {
@@ -654,9 +654,9 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleRemainingBudgetReset(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val ev = env
+  def handleRemainingBudgetReset(ctx: AdminExtensionRouterContext[AdminExtensionBackofficeAuthRoute], req: RequestHeader, user: Option[BackOfficeUser], body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     val all = req.getQueryString("all").contains("true")
     req.getQueryString("budget") match {
       case None => Results.NotFound(Json.obj("error" -> "no budget found")).vfuture
@@ -670,10 +670,10 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleBudgetClusterDeltaReceive(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleBudgetClusterDeltaReceive(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
+    given ev: Env = env
     (body match {
       case None => Results.Ok(Json.obj("done" -> false, "error" -> "no body")).vfuture
       case Some(bodySource) => bodySource.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
@@ -751,10 +751,9 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleBugdetReset(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleBugdetReset(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     val all = req.getQueryString("all").contains("true")
     ctx.named("id") match {
       case None => Results.BadRequest(Json.obj("error" -> "no budget id found")).vfuture
@@ -772,10 +771,9 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handleCurrentBudgetConsumption(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handleCurrentBudgetConsumption(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     ctx.named("id") match {
       case None => Results.BadRequest(Json.obj("error" -> "no budget id found")).vfuture
       case Some(budgetId) => {
@@ -791,21 +789,21 @@ class AiExtension(val env: Env) extends AdminExtension {
     }
   }
 
-  def handlePowChallengeCreate(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    ProofOfWorkPlugin.handlePowChallengeCreate(ctx, req, apikey, body)(env)
+  def handlePowChallengeCreate(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    ProofOfWorkPlugin.handlePowChallengeCreate(ctx, req, apikey, body)(using env)
   }
 
-  def handlePowChallengeRead(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    ProofOfWorkPlugin.handlePowChallengeRead(ctx, req, apikey, body)(env)
+  def handlePowChallengeRead(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    ProofOfWorkPlugin.handlePowChallengeRead(ctx, req, apikey, body)(using env)
   }
 
-  def handlePowChallengeDelete(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
-    ProofOfWorkPlugin.handlePowChallengeDelete(ctx, req, apikey, body)(env)
+  def handlePowChallengeDelete(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
+    ProofOfWorkPlugin.handlePowChallengeDelete(ctx, req, apikey, body)(using env)
   }
 
   // Catalog of every provider type the gateway supports, with their capabilities. Filter with one or
   // more `capabilities` query params (repeatable and/or comma-separated); a provider must expose ALL.
-  def handleProvidersCatalog(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
+  def handleProvidersCatalog(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
     val requested = (req.queryString.getOrElse("capabilities", Seq.empty) ++ req.queryString.getOrElse("capability", Seq.empty))
       .flatMap(_.split(",")).map(_.trim).filter(_.nonEmpty)
     Results.Ok(Json.obj(
@@ -815,7 +813,7 @@ class AiExtension(val env: Env) extends AdminExtension {
   }
 
   // List of model types (modalities) the gateway supports, each with the providers exposing it.
-  def handleModelCapabilities(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]]): Future[Result] = {
+  def handleModelCapabilities(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]]): Future[Result] = {
     Results.Ok(Json.obj(
       "object" -> "list",
       "data" -> AiProvidersCatalog.capabilitiesJson
@@ -951,13 +949,13 @@ class AiExtension(val env: Env) extends AdminExtension {
   override def assets(): Seq[AdminExtensionAssetRoute] = Seq(
     AdminExtensionAssetRoute(
       path = "/extensions/assets/cloud-apim/extensions/ai-extension/undraw_visionary_technology_re_jfp7.svg",
-      handle = (ctx: AdminExtensionRouterContext[AdminExtensionAssetRoute], req: RequestHeader) => {
+      handle = (_: AdminExtensionRouterContext[AdminExtensionAssetRoute], _: RequestHeader) => {
         Results.Ok(imgCode).as("image/svg+xml").vfuture
       }
     ),
     AdminExtensionAssetRoute(
       path = "/extensions/assets/cloud-apim/extensions/ai-extension/extension.js",
-      handle = (ctx: AdminExtensionRouterContext[AdminExtensionAssetRoute], req: RequestHeader) => {
+      handle = (_: AdminExtensionRouterContext[AdminExtensionAssetRoute], _: RequestHeader) => {
         Results.Ok(
           s"""(function() {
             |  const extensionId = "${id.value}";
@@ -2042,8 +2040,8 @@ class AiExtension(val env: Env) extends AdminExtension {
   )
 
   override def syncStates(): Future[Unit] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val ev = env
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     for {
       providers <- datastores.providersDatastore.findAllAndFillSecrets()
       templates <- datastores.promptTemplatesDatastore.findAllAndFillSecrets()

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/Faithfullness.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/Faithfullness.scala
@@ -1,11 +1,11 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.guardrails
 
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{Guardrail, GuardrailResult}
-import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmValidationSettings}
-import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, ChatPrompt, InputChatMessage, OutputChatMessage}
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
+import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, ChatPrompt}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, Json}
 
@@ -25,7 +25,7 @@ class FaithfulnessGuardrail extends Guardrail {
 
   def fail(): Future[GuardrailResult] = GuardrailResult.GuardrailDenied(s"request content is not faithful to the provided context").vfuture
 
-  def createStatements(userInput: String, ref: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[String]] = {
+  def createStatements(userInput: String, ref: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[String]] = {
     val instructions = """Given a question and an answer, analyze the complexity of each sentence in the answer.
         |Break down each sentence into one or more fully understandable statements.
         |Ensure that no pronouns are used in any statement.
@@ -51,7 +51,7 @@ class FaithfulnessGuardrail extends Guardrail {
     }
   }
 
-  def createVerdicts(context: String, statements: Seq[String], outOfScope: Boolean, ref: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[FaithfulnessOutput]] = {
+  def createVerdicts(context: String, statements: Seq[String], outOfScope: Boolean, ref: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[FaithfulnessOutput]] = {
     val instructions_notOutOfScope =
       """Your task is to judge the faithfulness of a series of statements based on a given context.
         |For each statement you must return verdict as 1 if the statement can be directly inferred based
@@ -96,7 +96,7 @@ class FaithfulnessGuardrail extends Guardrail {
   }
 
 
-  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val provider = config.select("ref").asOpt[String].orElse(config.select("provider").asOpt[String]).get
     val outOfScope = config.select("exclude_out_of_scope_statements").asOptBoolean.getOrElse(true)
     val context = config.select("context").asOpt[Seq[String]].map(_.mkString(". ")).orElse(config.select("context").asOpt[String]).getOrElse("--")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/hardcodedllm.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/hardcodedllm.scala
@@ -6,7 +6,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmVal
 import org.apache.commons.lang3.math.NumberUtils
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, Json}
 
@@ -250,7 +250,7 @@ abstract class HardCodedLLMGuardrail extends Guardrail {
     GuardrailResult.GuardrailDenied(msg).vfuture
   }
 
-  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val llmValidation = LlmValidationSettings.format.reads(config).getOrElse(LlmValidationSettings())
     llmValidation.provider match {
       case None => pass()

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/llm.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/llm.scala
@@ -5,7 +5,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmVal
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, ChatPrompt, InputChatMessage, OutputChatMessage}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, Json}
 
@@ -23,7 +23,7 @@ class LLMGuardrail extends Guardrail {
 
   def fail(idx: Int): Future[GuardrailResult] = GuardrailResult.GuardrailDenied(s"request content did not pass llm validation (${idx})").vfuture
 
-  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(_messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val llmValidation = LlmValidationSettings.format.reads(config).getOrElse(LlmValidationSettings())
     llmValidation.provider match {
       case None => pass()
@@ -44,7 +44,7 @@ class LLMGuardrail extends Guardrail {
                   validationClient.call(ChatPrompt(Seq(
                     ChatMessage.input("system", prompt.prompt, None, Json.obj())
                   ) ++ messages), attrs, Json.obj()).flatMap {
-                    case Left(err) => fail(2)
+                    case Left(_) => fail(2)
                     case Right(resp) => {
                       val content = resp.headGeneration.message.content.toLowerCase().trim.replace("\n", " ")
                       //  println(s"content: '${content}'")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/moderation.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/moderation.scala
@@ -5,7 +5,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{Guardrail, Guard
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsBoolean, JsObject, Json}
 
@@ -19,7 +19,7 @@ class ModerationGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = true
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val moderationModelRef = config.select("moderation_model").asString
     val ext = env.adminExtensions.extension[AiExtension].get
     ext.states.moderationModel(moderationModelRef) match {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/rampart.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/rampart.scala
@@ -8,13 +8,14 @@ import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, InputChatMessage, OutputChatMessage}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsObject, Json}
 import play.api.libs.typedmap.TypedKey
 
 import java.nio.LongBuffer
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
+import scala.compiletime.uninitialized
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -254,7 +255,7 @@ object RampartEngine {
     }
   }
 
-  private def resourceBytes(path: String)(implicit env: Env): Array[Byte] = {
+  private def resourceBytes(path: String)(using env: Env): Array[Byte] = {
     val is = env.environment.resourceAsStream(path).getOrElse(throw new RuntimeException(s"rampart: resource not found '$path'"))
     try {
       val buffer = new java.io.ByteArrayOutputStream()
@@ -266,15 +267,16 @@ object RampartEngine {
   }
 
   // the DJL tokenizer loads from a filesystem path, so extract the bundled tokenizer.json to a temp file once
-  private def resourceToTemp(path: String)(implicit env: Env): java.nio.file.Path = {
+  private def resourceToTemp(path: String)(using env: Env): java.nio.file.Path = {
     val tmp = java.nio.file.Files.createTempFile("rampart-tokenizer-", ".json")
     java.nio.file.Files.write(tmp, resourceBytes(path))
     tmp.toFile.deleteOnExit()
     tmp
   }
 
-  @volatile private var _instance: RampartEngine = _
-  def get(implicit env: Env): RampartEngine = {
+  @volatile private var _instance: RampartEngine = uninitialized
+
+  def get(using env: Env): RampartEngine = {
     val ref = _instance
     if (ref != null) ref
     else synchronized {
@@ -321,7 +323,7 @@ class RampartPiiGuardrail extends Guardrail {
   override def isAfter: Boolean = true
   override def manyMessages: Boolean = true // sees the whole conversation at once -> stable placeholders across turns
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val action = config.select("action").asOpt[String].getOrElse("redact").toLowerCase.trim
     val minScore = config.select("min_score").asOpt[Double].orElse(config.select("min_score").asOpt[String].map(_.toDouble)).getOrElse(0.4).toFloat
     val entities = config.select("entities").asOpt[Seq[String]].map(_.toSet).getOrElse(RampartPiiGuardrail.defaultEntities)
@@ -346,7 +348,7 @@ class RampartPiiGuardrail extends Guardrail {
     }
   }
 
-  private def applyAction(messages: Seq[ChatMessage], engine: RampartEngine, action: String, minScore: Float, entities: Set[String], attrs: TypedMap, store: Boolean)(implicit env: Env): GuardrailResult = {
+  private def applyAction(messages: Seq[ChatMessage], engine: RampartEngine, action: String, minScore: Float, entities: Set[String], attrs: TypedMap, store: Boolean)(using env: Env): GuardrailResult = {
     action match {
       case "block" =>
         if (messages.exists(m => engine.detectAll(m.wholeTextContent, minScore, entities).nonEmpty)) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/regex.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/regex.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.guardrails
 
-import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, ChatMessageContent, InputChatMessage, OutputChatMessage}
+import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, InputChatMessage, OutputChatMessage}
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{Guardrail, GuardrailResult}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi.utils.{RegexPool, TypedMap}
 import play.api.libs.json.JsObject
 
@@ -24,7 +24,7 @@ class RegexGuardrail extends Guardrail {
     !denied && allowed
   }
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val allow = config.select("allow").asOpt[Seq[String]].getOrElse(Seq.empty)
     val deny = config.select("deny").asOpt[Seq[String]].getOrElse(Seq.empty)
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/text.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/text.scala
@@ -6,11 +6,11 @@ import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import dev.langchain4j.data.segment.TextSegment
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.JsObject
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters.*
 
 class ContainsGuardrail extends Guardrail {
 
@@ -20,7 +20,7 @@ class ContainsGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = false
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val matchAllConversation = false //config.select("match_all_conversation").asOpt[Boolean].getOrElse(false)
     val operation = config.select("operation").asOpt[String].getOrElse("contains_all")
     val values = config.select("values").asOpt[Seq[String]].getOrElse(Seq.empty)
@@ -42,7 +42,7 @@ class SemanticContainsGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = false
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = env.metrics.withTimer("semantic_contains") {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = env.metrics.withTimer("semantic_contains") {
     val operation = config.select("operation").asOpt[String].getOrElse("contains_all")
     val values = config.select("values").asOpt[Seq[String]].getOrElse(Seq.empty)
     val score = config.select("score").asOpt[Double].orElse(config.select("score").asOpt[String].map(_.toDouble)).getOrElse(0.8)
@@ -85,7 +85,7 @@ class CharactersCountGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = false
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val message = messages.head
     val min = config.select("min").asOpt[Long].getOrElse(0L)
     val max = config.select("max").asOpt[Long].getOrElse(Long.MaxValue)
@@ -107,7 +107,7 @@ class WordsCountGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = false
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val message = messages.head
     val min = config.select("min").asOpt[Long].getOrElse(0L)
     val max = config.select("max").asOpt[Long].getOrElse(Long.MaxValue)
@@ -129,7 +129,7 @@ class SentencesCountGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = false
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val message = messages.head
     val min = config.select("min").asOpt[Long].getOrElse(0L)
     val max = config.select("max").asOpt[Long].getOrElse(Long.MaxValue)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/wasm.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/wasm.scala
@@ -3,17 +3,17 @@ package com.cloud.apim.otoroshi.extensions.aigateway.guardrails
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{Guardrail, GuardrailResult}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.LlmToolFunctionBackendOptions.getCode
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmToolFunction}
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import io.otoroshi.wasm4s.scaladsl.{ResultsWrapper, WasmFunctionParameters}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object WasmGuardrail {
-  def handleCallResult(from: String, res: Either[JsValue, (String, ResultsWrapper)])(implicit ec: ExecutionContext, env: Env): GuardrailResult = res match {
+  def handleCallResult(from: String, res: Either[JsValue, (String, ResultsWrapper)])(using ec: ExecutionContext, env: Env): GuardrailResult = res match {
     case Left(err) =>
       err.prettify
       GuardrailResult.GuardrailError(err.stringify)
@@ -53,7 +53,7 @@ class WasmGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = true
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val wasmPlugin: Option[String] = config.select("wasmPlugin").asOpt[String].orElse(config.select("plugin_ref").asOpt[String]).filter(_.trim.nonEmpty)
     wasmPlugin match {
       case None => GuardrailResult.GuardrailError("error, not wasm plugin ref").vfuture
@@ -112,7 +112,7 @@ class QuickJsGuardrail extends Guardrail {
        |""".stripMargin.vfuture
   }
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val jsPath: Option[String] = config.select("jsPath").asOpt[String].orElse(config.select("quickjs_path").asOpt[String]).filter(_.trim.nonEmpty)
     jsPath match {
       case None => GuardrailResult.GuardrailError("error, not wasm plugin ref").vfuture
@@ -120,7 +120,7 @@ class QuickJsGuardrail extends Guardrail {
         getCode(path, Map.empty, getDefaultGuardrailCallCode).flatMap { code =>
           env.wasmIntegration.wasmVmFor(LlmToolFunction.wasmConfigRef).flatMap {
             case None =>  GuardrailResult.GuardrailError("unable to create wasm vm").vfuture
-            case Some((vm, localconfig)) => {
+            case Some((vm, _)) => {
               val arr = messages.map {
                 case i: InputChatMessage => i.json(ChatMessageContentFlavor.Common)
                 case o: OutputChatMessage => o.json

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/webhook.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/webhook.scala
@@ -6,18 +6,19 @@ import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatMessage, Ch
 import com.github.blemale.scaffeine.Scaffeine
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsArray, JsObject}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object WebhookGuardrail {
   val cache = Scaffeine()
     .expireAfter[String, (FiniteDuration, Boolean)](
-      create = (key, value) => value._1,
-      update = (key, value, currentDuration) => currentDuration,
-      read = (key, value, currentDuration) => currentDuration
+      create = (_, value) => value._1,
+      update = (_, _, currentDuration) => currentDuration,
+      read = (_, _, currentDuration) => currentDuration
     )
     .maximumSize(5000)
     .build[String, (FiniteDuration, Boolean)]()
@@ -31,7 +32,7 @@ class WebhookGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = true
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val key = messages.map(m => s"${m.role}:${m.wholeTextContent}").mkString(",").sha512
     val httpValidation = HttpValidationSettings.format.reads(config).getOrElse(HttpValidationSettings())
     httpValidation.url match {
@@ -47,7 +48,7 @@ class WebhookGuardrail extends Guardrail {
             }
             env.Ws
               .url(httpValidation.url.get)
-              .withHttpHeaders(httpValidation.headers.toSeq: _*)
+              .withHttpHeaders(httpValidation.headers.toSeq*)
               .post(JsArray(arr)).flatMap { resp =>
                 if (resp.status != 200) {
                   WebhookGuardrail.cache.put(key, (httpValidation.ttl, false))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/workflow.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/guardrails/workflow.scala
@@ -6,7 +6,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
 import otoroshi.next.workflow.{Node, WorkflowAdminExtension}
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsArray, JsNull, JsObject, Json}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,7 +19,7 @@ class WorkflowGuardrail extends Guardrail {
 
   override def manyMessages: Boolean = true
 
-  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
+  override def pass(messages: Seq[ChatMessage], config: JsObject, provider: Option[AiProvider], chatClient: Option[ChatClient], attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[GuardrailResult] = {
     val workflowId: Option[String] = config.select("workflow_id").asOpt[String].orElse(config.select("workflow_ref").asOpt[String]).filter(_.trim.nonEmpty)
     workflowId match {
       case None => GuardrailResult.GuardrailError("error, no workflow ref").vfuture

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/kreuzberg.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/kreuzberg.scala
@@ -3,7 +3,7 @@ package com.cloud.apim.otoroshi.extensions.aigateway
 import dev.kreuzberg.Kreuzberg
 import dev.kreuzberg.config.{ExtractionConfig, OcrConfig}
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
 
 import java.nio.file.Path
@@ -42,7 +42,7 @@ object KreuzbergHelper {
       .useCache(false)
       .build()
 
-  def extractFromBytes(bytes: Array[Byte], mimeType: String)(implicit env: Env, ec: ExecutionContext): Future[String] = {
+  def extractFromBytes(bytes: Array[Byte], mimeType: String)(using env: Env, ec: ExecutionContext): Future[String] = {
     if (!canExecuteKreuzberg) return Future.failed(new RuntimeException(errorMsg))
     env.metrics.withTimer("kreuzberg.extractFromBytes", display = true) {
       val result = Kreuzberg.extractBytes(bytes, mimeType, defaultConfig)
@@ -50,19 +50,19 @@ object KreuzbergHelper {
     }
   }
 
-  def extractFromFile(path: Path)(implicit ec: ExecutionContext): Future[String] = {
+  def extractFromFile(path: Path)(using ec: ExecutionContext): Future[String] = {
     if (!canExecuteKreuzberg) return Future.failed(new RuntimeException(errorMsg))
       val result = Kreuzberg.extractFile(path, defaultConfig)
       result.getContent.vfuture
   }
 
-  def extractFromUrl(url: String, method: String = "GET", headers: Map[String, String] = Map.empty)(implicit env: Env, ec: ExecutionContext): Future[(String, String)] = {
+  def extractFromUrl(url: String, method: String = "GET", headers: Map[String, String] = Map.empty)(using env: Env, ec: ExecutionContext): Future[(String, String)] = {
     if (!canExecuteKreuzberg) return Future.failed(new RuntimeException(errorMsg))
     val req = env.Ws
       .url(url)
       .withFollowRedirects(true)
       .withRequestTimeout(scala.concurrent.duration.Duration(30000L, "millis"))
-      .withHttpHeaders(headers.toSeq: _*)
+      .withHttpHeaders(headers.toSeq*)
     req.execute(method).flatMap { resp =>
       val contentType = resp.header("Content-Type").getOrElse("application/octet-stream")
       val mimeType = contentType.split(";").head.trim

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/meta_mcp_client.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/meta_mcp_client.scala
@@ -5,19 +5,19 @@ import com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic.ExpressionLa
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{McpConnector, McpSupport}
 import dev.langchain4j.agent.tool.{ToolExecutionRequest, ToolSpecification}
 import dev.langchain4j.invocation.InvocationContext
-import dev.langchain4j.mcp.client._
-import dev.langchain4j.model.chat.request.json._
+import dev.langchain4j.mcp.client.*
+import dev.langchain4j.model.chat.request.json.*
 import dev.langchain4j.service.tool.ToolExecutionResult
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 private final case class MetaToolEntry(serverSlug: String, serverName: String, serverId: String, tool: ToolSpecification) {
@@ -184,8 +184,8 @@ object MetaMcpClient {
 
 class MetaMcpClient(connector: McpConnector, env: Env, ec: ExecutionContext) extends McpClient {
 
-  private implicit val _env: Env = env
-  private implicit val _ec: ExecutionContext = ec
+  private given _env: Env = env
+  private given _ec: ExecutionContext = ec
 
   override def subscribeToResource(uri: String): Unit = ()
 
@@ -412,7 +412,7 @@ class MetaMcpClient(connector: McpConnector, env: Env, ec: ExecutionContext) ext
     if (query.isEmpty) return Future.successful((true, "missing required argument 'query'"))
     val filterServers = args.select("servers").asOpt[Seq[String]].map(_.toSet).getOrElse(Set.empty[String])
     ensureSearchIndex().map { idx =>
-      val filterFn: ((String, _)) => Boolean = {
+      val filterFn: ((String, ?)) => Boolean = {
         case (docId, _) =>
           if (filterServers.isEmpty) true else idx.entries.get(docId).exists(e => filterServers.contains(e.serverSlug))
       }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/openapi_mcp_client.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/openapi_mcp_client.scala
@@ -6,19 +6,20 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import dev.langchain4j.agent.tool.{ToolExecutionRequest, ToolSpecification}
 import dev.langchain4j.invocation.InvocationContext
-import dev.langchain4j.mcp.client._
-import dev.langchain4j.model.chat.request.json._
+import dev.langchain4j.mcp.client.*
+import dev.langchain4j.model.chat.request.json.*
 import dev.langchain4j.service.tool.ToolExecutionResult
 import otoroshi.env.Env
 import otoroshi.utils.RegexPool
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 import java.{util => ju}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 /**
  * Converts an OpenAPI / JSON-Schema fragment (Play JSON) into a langchain4j `JsonSchemaElement`.
@@ -223,8 +224,7 @@ object OpenApiMcpClient {
 
 class OpenApiMcpClient(connector: McpConnector, env: Env, ec: ExecutionContext) extends McpClient {
 
-  private implicit val _env: Env = env
-  private implicit val _ec: ExecutionContext = ec
+  private given _ec: ExecutionContext = ec
 
   private def opts = connector.transport.openapiOptions
 
@@ -512,7 +512,7 @@ class OpenApiMcpClient(connector: McpConnector, env: Env, ec: ExecutionContext) 
               val hasBody = body.isDefined && method != "GET" && method != "HEAD"
               val headers = Map("Accept" -> "application/json") ++ opts.headers ++ headerParams.toMap ++ (if (hasBody) Map("Content-Type" -> "application/json") else Map.empty)
               var builder = env.Ws.url(finalUrl)
-                .withHttpHeaders(headers.toSeq: _*)
+                .withHttpHeaders(headers.toSeq*)
                 .withMethod(method)
                 .withRequestTimeout(opts.timeout)
                 .withFollowRedirects(false)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/transport.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/mcp/transport.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
+import play.api.libs.ws.WSBodyWritables.given
 
 
 object WsMcpTransport {
@@ -41,7 +42,7 @@ class WsMcpTransport(
                       timeout: FiniteDuration,
                       log: Boolean,
                       name: String = "ws-mcp",
-                    )(implicit ec: ExecutionContext, env: Env) extends McpTransport {
+                    )(using ec: ExecutionContext, env: Env) extends McpTransport {
 
   private val mapper: ObjectMapper = WsMcpTransport.OBJECT_MAPPER
   private val logger: Logger = WsMcpTransport.logger
@@ -126,7 +127,7 @@ class WsMcpTransport(
 
     val started = System.currentTimeMillis()
     env.Ws.url(url)
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .withMethod("POST")
       .withBody(body)
@@ -161,13 +162,13 @@ class WsMcpTransport(
           val err = new RuntimeException(s"Unexpected status code $status: ${raw.take(500)}")
           future.completeExceptionally(err)
         }
-      }(ec)
+      }(using ec)
       .recover {
         case t: Throwable =>
           trace(s"error: ${t.getClass.getSimpleName}: ${t.getMessage}")
           future.completeExceptionally(t)
           Option(onFailureRef.get()).foreach(_.run())
-      }(ec)
+      }(using ec)
 
     future
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/metrics.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/metrics.scala
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success}
 object AiMetrics {
 
   // calls/errors/duration for a single AI operation, plus aggregate and per-provider-kind breakdown.
-  def markOperation(op: String, providerKind: Option[String], durationMs: Long, isError: Boolean)(implicit env: Env): Unit = {
+  def markOperation(op: String, providerKind: Option[String], durationMs: Long, isError: Boolean)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     val kind = providerKind.map(_.trim.toLowerCase).filter(_.nonEmpty)
     env.metrics.counterInc("ai.calls")
@@ -32,7 +32,7 @@ object AiMetrics {
   }
 
   // cumulative token counters (counterIncOf increments by amount) — gives token-rate / totals in dashboards.
-  def markTokens(promptT: Int, genT: Int, reasoningT: Int)(implicit env: Env): Unit = {
+  def markTokens(promptT: Int, genT: Int, reasoningT: Int)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     if (promptT > 0) env.metrics.counterIncOf("ai.tokens.prompt", promptT.toLong)
     if (genT > 0) env.metrics.counterIncOf("ai.tokens.generation", genT.toLong)
@@ -42,13 +42,13 @@ object AiMetrics {
   }
 
   // cumulative cost in micro-USD (rounded). Precise accounting stays in LLMUsageAudit / budgets.
-  def markCost(total: Double)(implicit env: Env): Unit = {
+  def markCost(total: Double)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     if (total > 0) env.metrics.counterIncOf("ai.cost.micro_usd", Math.round(total * 1000000.0))
   }
 
   // cache hit/miss; kind = "simple" | "semantic".
-  def markCache(kind: String, hit: Boolean)(implicit env: Env): Unit = {
+  def markCache(kind: String, hit: Boolean)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     val outcome = if (hit) "hit" else "miss"
     env.metrics.counterInc(s"ai.cache.$outcome")
@@ -56,30 +56,30 @@ object AiMetrics {
   }
 
   // per-guardrail outcome; kind = guardrail key (regex, llm, prompt_injection, ...), outcome = pass|deny|error.
-  def markGuardrail(kind: String, outcome: String)(implicit env: Env): Unit = {
+  def markGuardrail(kind: String, outcome: String)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc("ai.guardrail.calls")
     env.metrics.counterInc(s"ai.guardrail.$outcome")
     env.metrics.counterInc(s"ai.guardrail.$kind.$outcome")
   }
 
-  def markFallback()(implicit env: Env): Unit = {
+  def markFallback()(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc("ai.fallback.calls")
   }
 
-  def markBudgetExceeded()(implicit env: Env): Unit = {
+  def markBudgetExceeded()(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc("ai.budget.exceeded")
   }
 
-  def markModelConstraintDenied()(implicit env: Env): Unit = {
+  def markModelConstraintDenied()(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc("ai.model_constraint.denied")
   }
 
   // circuit-breaker state transition; state = open|close|half_open.
-  def markCircuit(state: String)(implicit env: Env): Unit = {
+  def markCircuit(state: String)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc(s"ai.circuit.$state")
   }
@@ -88,7 +88,7 @@ object AiMetrics {
   // Left carries a "budget exceeded" error), and runs `onSuccess` (e.g. token/cost metrics) only on Right.
   // For streaming ops the Right is the source returned before consumption, so duration is time-to-stream-start
   // and token/cost metrics must be recorded separately at stream completion.
-  def around[T](op: String, providerKind: String, start: Long, f: Future[Either[JsValue, T]])(onSuccess: T => Unit)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
+  def around[T](op: String, providerKind: String, start: Long, f: Future[Either[JsValue, T]])(onSuccess: T => Unit)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, T]] = {
     f.andThen {
       case Success(Right(v)) =>
         markOperation(op, Some(providerKind), System.currentTimeMillis() - start, isError = false)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/models.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/models.scala
@@ -1,20 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{CostsOutput, ImpactsOutput}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiBudget, AiBudgetConsumptions}
-import diffson.DiffOps
 import otoroshi.env.Env
-import otoroshi.gateway.Errors.messages
 import otoroshi.security.IdGenerator
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.AnthropicStreamResponseState
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedKey
-import play.api.mvc.RequestHeader
 
 import java.nio.ByteOrder
 import java.util.Base64
@@ -161,6 +158,7 @@ object ChatMessageContent {
             val base64 = base.split("base64,")(1).byteString.decodeBase64
             (None, base64.some, media)
           }
+          case other => throw new IllegalArgumentException(s"unsupported image_url.url: ${other}")
         }
         ImageContent(openaiMediaType, openaiUrl, openaiData)
       }
@@ -169,6 +167,7 @@ object ChatMessageContent {
         val format = json.at("input_audio.format").asString match {
           case "wav" => "audio/x-wav"
           case "mp3" => "audio/mpeg3"
+          case other => throw new IllegalArgumentException(s"unsupported input_audio.format: ${other}")
         }
         AudioContent(format, None, data.some)
       }
@@ -464,7 +463,7 @@ case class InputChatMessage(role: String, contentParts: Seq[ChatMessageContent],
     case (obj, tool_call_id) => obj ++ Json.obj("tool_call_id" -> tool_call_id)
   }.applyOnWithOpt(tool_calls) {
     case (obj, tool_calls) => obj ++ Json.obj("tool_calls" -> tool_calls)
-  }.applyOnIf(flavor == ChatMessageContentFlavor.Anthropic && isSystem) { obj =>
+  }.applyOnIf(flavor == ChatMessageContentFlavor.Anthropic && isSystem) { _ =>
      Json.obj("type" -> "text", "text" -> wholeTextContent)
   }.applyOnIf(flavor == ChatMessageContentFlavor.Ollama && hasImage) { obj =>
     val aggContent = contentParts.collect {
@@ -818,7 +817,7 @@ case class ChatResponse(
       case (o, budget) => o ++ Json.obj("budget" -> budget._1.jsonWithRemaining(budget._2))
     }
   }
-  def toSource(model: String): Source[ChatResponseChunk, _] = {
+  def toSource(model: String): Source[ChatResponseChunk, ?] = {
     val id = s"chatgen-${IdGenerator.token(32)}"
     val finalModel = raw.select("model").asOpt[String].getOrElse(model)
     Source(generations.toList)
@@ -832,7 +831,7 @@ case class ChatResponse(
         ChatResponseChunk(id, System.currentTimeMillis() / 1000, finalModel, Seq(ChatResponseChunkChoice(0, ChatResponseChunkChoiceDelta(None, None), Some("stop"))))
       ))
   }
-  def toResponseSource(model: String): Source[ChatResponseChunk, _] = toSource(model)
+  def toResponseSource(model: String): Source[ChatResponseChunk, ?] = toSource(model)
 }
 sealed trait ChatResponseCacheStatus {
   def name: String
@@ -978,7 +977,7 @@ case class ChatResponseChunkChoiceDelta(
   }.applyOnWithOpt(reasoning.filter(_.nonEmpty)) {
     case (o, reasoning) => o ++ Json.obj("reasoning_content" -> reasoning)
   }.applyOnWithOpt(refusal) {
-    case (o, content) => o ++ Json.obj("refusal" -> refusal)
+    case (o, _) => o ++ Json.obj("refusal" -> refusal)
   }.applyOnIf(tool_calls.nonEmpty) { o =>
     o ++ Json.obj("tool_calls" -> JsArray(tool_calls.map(_.json)))
   }
@@ -1003,7 +1002,7 @@ case class ChatResponseChunkChoice(index: Long, delta: ChatResponseChunkChoiceDe
     "finish_reason" -> finishReason.map(_.json).getOrElse(JsNull).asValue
   )
   def hasToolCall: Boolean = delta.tool_calls.nonEmpty
-  def anthropicContentBlockDeltaJson(env: Env, state: AnthropicStreamResponseState): Source[ByteString, _] = {
+  def anthropicContentBlockDeltaJson(env: Env, state: AnthropicStreamResponseState): Source[ByteString, ?] = {
     var list = Seq.empty[ByteString]
     if (delta.tool_calls.nonEmpty) {
       if (!state.textDone.get() && !state.toolCallsStarted.get()) {
@@ -1114,7 +1113,7 @@ case class ChatResponseChunk(id: String, created: Long, model: String, choices: 
   def eventSource(env: Env): ByteString = s"data: ${json(env).stringify}\n\n".byteString
   def openaiEventSource(env: Env): ByteString = s"data: ${openaiJson(env).stringify}\n\n".byteString
   def openaiCompletionEventSource(env: Env): ByteString = s"data: ${openaiCompletionJson(env).stringify}\n\n".byteString
-  def anthropicContentBlockDeltaEventSource(env: Env, state: AnthropicStreamResponseState): Source[ByteString, _] = {
+  def anthropicContentBlockDeltaEventSource(env: Env, state: AnthropicStreamResponseState): Source[ByteString, ?] = {
     Source(choices.toList).flatMapConcat { choice =>
       choice.anthropicContentBlockDeltaJson(env, state)
     }
@@ -1204,7 +1203,7 @@ object EmbeddingClientInputOptions {
 }
 
 trait EmbeddingModelClient {
-  def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]]
+  def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]]
 }
 
 object EmbeddingModelClient {
@@ -1295,9 +1294,9 @@ object EmbeddingSearchOptions {
 }
 
 trait EmbeddingStoreClient {
-  def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
-  def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
-  def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]]
+  def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
+  def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
+  def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]]
 }
 
 case class PersistedChatMessage(raw: JsObject) {
@@ -1314,7 +1313,7 @@ object PersistedChatMessage {
 
 trait PersistentMemoryClient {
   def config: JsObject
-  def addMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  def addMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getMessages(sessionId).flatMap {
       case Left(error) => error.leftf
       case Right(oldMessages) => {
@@ -1328,10 +1327,10 @@ trait PersistentMemoryClient {
       }
     }
   }
-  def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
-  def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]]
-  def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
-  def applyStrategy(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
+  def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]]
+  def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]]
+  def applyStrategy(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     val options = config.select("options")
     options.select("strategy").asOptString.getOrElse("message_window") match {
       case "message_window" => {
@@ -1517,7 +1516,7 @@ object ModerationModelClientInputOptions {
 }
 
 trait ModerationModelClient {
-  def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]]
+  def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]]
 }
 
 object ModerationModelClient {
@@ -1655,7 +1654,7 @@ object AudioModelClientTextToSpeechInputOptions {
 }
 
 case class AudioModelClientSpeechToTextInputOptions(
-  file: Source[ByteString, _],
+  file: Source[ByteString, ?],
   fileName: Option[String],
   fileContentType: String,
   fileLength: Long,
@@ -1703,7 +1702,7 @@ object AudioModelClientSpeechToTextInputOptions {
 
 
 case class AudioModelClientTranslationInputOptions(
-  file: Source[ByteString, _],
+  file: Source[ByteString, ?],
   fileName: Option[String],
   fileContentType: String,
   fileLength: Long,
@@ -1751,17 +1750,17 @@ trait AudioModelClient {
   def supportsStt: Boolean
   def supportsTranslation: Boolean
 
-  def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  def translate(options: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     Left(Json.obj("error" -> "audio translation not supported")).vfuture
   }
-  def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  def speechToText(options: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     Left(Json.obj("error" -> "speech to text not supported")).vfuture
   }
-  def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  def textToSpeech(options: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     Left(Json.obj("error" -> "text to speech not supported")).vfuture
   }
-  def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
-  def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = Left(Json.obj("error" -> "voices list not supported")).vfuture
+  def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
+  def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = Left(Json.obj("error" -> "voices list not supported")).vfuture
 }
 
 object AudioModelClient {
@@ -1876,8 +1875,8 @@ case class OcrModelClientResponse(model: String, text: String, pages: Seq[OcrMod
 
 trait OcrModelClient {
   def supportsOcr: Boolean = true
-  def ocr(options: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]]
-  def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
+  def ocr(options: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]]
+  def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
 }
 
 object OcrModelClient {
@@ -1962,7 +1961,7 @@ case class SearchEngineResponse(
 }
 
 trait SearchEngineClient {
-  def search(options: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]]
+  def search(options: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]]
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2020,7 +2019,7 @@ object ImageModelClientGenerationInputOptions {
   }
 }
 
-case class ImageFile(bytes: Source[ByteString, _],
+case class ImageFile(bytes: Source[ByteString, ?],
                      name: Option[String],
                      contentType: String,
                      length: Long)
@@ -2122,8 +2121,8 @@ case class ImagesGenResponse(
 trait ImageModelClient {
   def supportsGeneration: Boolean
   def supportsEdit: Boolean
-  def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = Json.obj("error" -> "Image generation not supported").leftf
-  def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = Json.obj("error" -> "Image edition not supported").leftf
+  def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = Json.obj("error" -> "Image generation not supported").leftf
+  def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = Json.obj("error" -> "Image edition not supported").leftf
 }
 
 object ImageModelClient {
@@ -2222,7 +2221,7 @@ object VideoModelClientTextToVideoInputOptions {
 
 trait VideoModelClient {
   def supportsTextToVideo: Boolean
-  def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]]
+  def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]]
 }
 
 object VideoModelClient {
@@ -2274,7 +2273,7 @@ trait ChatClient {
 
   def transformOpenAIInputBodyToProviderInputBody(inputBody: JsObject): JsObject = inputBody
 
-  def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
+  def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = Left(Json.obj("error" -> "models list not supported")).vfuture
 
   /**
    * Single blocking entry point. Implemented once by every decorator (see `DecoratorChatClient`) and
@@ -2285,22 +2284,22 @@ trait ChatClient {
    * never forward the caller's own `messages` / `input` array: decorators (prompt contexts,
    * persistent memory, guardrail transforms) rewrite the prompt and never touch `originalBody`.
    */
-  def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = kind match {
+  def invoke(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = kind match {
     case ChatCallKind.Chat => call(prompt, attrs, originalBody)
     case ChatCallKind.Completion => completion(prompt, attrs, originalBody)
     case ChatCallKind.Responses => response(prompt, attrs, originalBody)
   }
 
   /** streaming counterpart of `invoke`, same contract */
-  def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = kind match {
+  def invokeStream(kind: ChatCallKind, prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = kind match {
     case ChatCallKind.Chat => stream(prompt, attrs, originalBody)
     case ChatCallKind.Completion => completionStream(prompt, attrs, originalBody)
     case ChatCallKind.Responses => responseStream(prompt, attrs, originalBody)
   }
 
-  def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]]
+  def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]]
 
-  def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     Left(Json.obj("error" -> "completion not supported")).vfuture
   }
 
@@ -2309,23 +2308,23 @@ trait ChatClient {
    * converting the body with `OpenAiResponsesBodyConverter` — tools included — which is the right
    * behaviour for every provider without a native `/responses` endpoint.
    */
-  def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     call(prompt, attrs, OpenAiResponsesBodyConverter.toChatCompletionsBody(originalBody))
   }
 
-  def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     Left(Json.obj("error" -> "streaming not supported")).future
   }
 
-  def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     Left(Json.obj("error" -> "streaming not supported")).future
   }
 
-  def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     stream(prompt, attrs, OpenAiResponsesBodyConverter.toChatCompletionsBody(originalBody))
   }
 
-  final def tryStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  final def tryStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (supportsStreaming) {
       stream(prompt, attrs, originalBody)
     } else {
@@ -2336,7 +2335,7 @@ trait ChatClient {
     }
   }
 
-  def tryCompletion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  def tryCompletion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     if (supportsCompletion) {
       completion(prompt, attrs, originalBody)
     } else {
@@ -2345,7 +2344,7 @@ trait ChatClient {
     }
   }
 
-  final def tryCompletionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  final def tryCompletionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (supportsStreaming) {
       completionStream(prompt, attrs, originalBody)
     } else {
@@ -2359,11 +2358,11 @@ trait ChatClient {
 
   // `response` already handles the non-native case by degrading to /chat/completions, so there is
   // nothing left to try: kept for symmetry with tryCompletion/tryStream at the call sites.
-  final def tryResponse(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  final def tryResponse(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     response(prompt, attrs, originalBody)
   }
 
-  final def tryResponseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  final def tryResponseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (supportsStreaming) {
       responseStream(prompt, attrs, originalBody)
     } else {
@@ -2382,12 +2381,12 @@ trait ChatClient {
  * `/responses`, which is exactly the class of bug this trait exists to prevent.
  */
 trait KindBasedChatClient extends ChatClient {
-  final override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Chat, prompt, attrs, originalBody)
-  final override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Completion, prompt, attrs, originalBody)
-  final override def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Responses, prompt, attrs, originalBody)
-  final override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = invokeStream(ChatCallKind.Chat, prompt, attrs, originalBody)
-  final override def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = invokeStream(ChatCallKind.Completion, prompt, attrs, originalBody)
-  final override def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = invokeStream(ChatCallKind.Responses, prompt, attrs, originalBody)
+  final override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Chat, prompt, attrs, originalBody)
+  final override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Completion, prompt, attrs, originalBody)
+  final override def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = invoke(ChatCallKind.Responses, prompt, attrs, originalBody)
+  final override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = invokeStream(ChatCallKind.Chat, prompt, attrs, originalBody)
+  final override def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = invokeStream(ChatCallKind.Completion, prompt, attrs, originalBody)
+  final override def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = invokeStream(ChatCallKind.Responses, prompt, attrs, originalBody)
 }
 
 object ChatClient {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/openairesponses.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/openairesponses.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway
 
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 /**
  * Translation between the OpenAI Responses API shape (`/responses`) and the chat/completions shape

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/a2a.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/a2a.scala
@@ -1,22 +1,22 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.a2a._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.a2a.*
 import com.cloud.apim.otoroshi.extensions.aigateway.agents.{AgentConfig, AgentInput, AgentRunConfig}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.A2AServer
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessageContent, ChatResponseChunk, InputChatMessage}
 import otoroshi.env.Env
 import otoroshi.next.models.{NgPluginInstance, NgPluginInstanceConfig}
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
 import otoroshi.next.workflow.{Node, WorkflowAdminExtension}
 import otoroshi.utils.TypedMap
 import otoroshi.utils.http.RequestImplicits.EnhancedRequestHeader
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,7 +59,7 @@ object A2AServerPluginConfig {
 object A2ASupportServer {
 
   // base url of the JSON-RPC endpoint (route root), derived from the incoming request
-  def interfaceUrl(ctx: NgbBackendCallContext)(implicit env: Env): String = {
+  def interfaceUrl(ctx: NgbBackendCallContext)(using env: Env): String = {
     val proto = ctx.rawRequest.theProtocol
     val host = ctx.rawRequest.theHost
     val basePath = ctx.request.path
@@ -68,7 +68,7 @@ object A2ASupportServer {
     s"$proto://$host$basePath"
   }
 
-  def server(ref: String)(implicit env: Env): Option[A2AServer] =
+  def server(ref: String)(using env: Env): Option[A2AServer] =
     env.adminExtensions.extension[AiExtension].flatMap(_.states.a2aServer(ref))
 
   // map A2A message parts (v1.0 unified part: text|url|raw|data + mediaType) to the extension's chat content parts
@@ -96,7 +96,7 @@ object A2ASupportServer {
   }
 
   // execute the configured backend (inline agent or workflow ref) for an A2A message, return the textual result
-  def executeBackend(srv: A2AServer, message: A2AMessage, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
+  def executeBackend(srv: A2AServer, message: A2AMessage, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, String]] = {
     val text = message.textContent
     srv.backend.kind.toLowerCase match {
       case "agent" =>
@@ -105,7 +105,7 @@ object A2ASupportServer {
           case Some(agentJson) =>
             Try(AgentConfig.from(agentJson)) match {
               case Failure(e) => Json.obj("error" -> s"invalid agent config: ${e.getMessage}").leftf
-              case Success(agent) => agent.run(buildAgentInput(message), AgentRunConfig(), attrs, None)(env).map(_.map(_.wholeTextContent))
+              case Success(agent) => agent.run(buildAgentInput(message), AgentRunConfig(), attrs, None)(using env).map(_.map(_.wholeTextContent))
             }
         }
       case "workflow" =>
@@ -140,7 +140,7 @@ object A2ASupportServer {
 
   // streaming variant for the inline-agent backend; returns Left for backends/agents that can't stream token-by-token
   // (workflow, handoffs, built-in tools) so the caller falls back to a blocking single-artifact emission.
-  def streamBackend(srv: A2AServer, message: A2AMessage, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  def streamBackend(srv: A2AServer, message: A2AMessage, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     srv.backend.kind.toLowerCase match {
       case "agent" =>
         srv.backend.agent match {
@@ -148,7 +148,7 @@ object A2ASupportServer {
           case Some(agentJson) =>
             Try(AgentConfig.from(agentJson)) match {
               case Failure(e) => Json.obj("error" -> s"invalid agent config: ${e.getMessage}").leftf
-              case Success(agent) => agent.stream(buildAgentInput(message), AgentRunConfig(), attrs, None)(env)
+              case Success(agent) => agent.stream(buildAgentInput(message), AgentRunConfig(), attrs, None)(using env)
             }
         }
       case _ => Json.obj("error" -> "backend not streamable").leftf
@@ -170,7 +170,7 @@ class A2AAgentCardPlugin extends NgBackendCall {
   override def configFlow: Seq[String] = A2AServerPluginConfig.configFlow
   override def configSchema: Option[JsObject] = A2AServerPluginConfig.configSchema
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(A2AServerPluginConfig.format).getOrElse(A2AServerPluginConfig.default)
     A2ASupportServer.server(config.ref) match {
       case None => NgProxyEngineError.NgResultProxyEngineError(Results.NotFound(Json.obj("error" -> "a2a server not found"))).leftf
@@ -202,7 +202,7 @@ class A2AServerPlugin extends NgBackendCall {
   private def rpcErr(id: JsValue, code: Int, message: String, data: Option[JsValue] = None): Future[Either[NgProxyEngineError, BackendCallResponse]] =
     BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(A2AJsonRpc.err(id, code, message, data))), None).rightf
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(A2AServerPluginConfig.format).getOrElse(A2AServerPluginConfig.default)
     val method = ctx.request.method.toUpperCase()
     val path = ctx.request.path
@@ -243,7 +243,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleSendMessage(id: JsValue, json: JsValue, srv: A2AServer, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleSendMessage(id: JsValue, json: JsValue, srv: A2AServer, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val params = json.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val msgJson = params.select("message").asOpt[JsValue].getOrElse(Json.obj())
     A2AMessage.format.reads(msgJson).asOpt match {
@@ -288,7 +288,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleGetTask(id: JsValue, json: JsValue)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleGetTask(id: JsValue, json: JsValue)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val taskId = json.at("params.id").asOpt[String].getOrElse("")
     if (taskId.isEmpty) {
       rpcErr(id, A2AErrors.InvalidParams, "missing 'id' param")
@@ -300,7 +300,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleCancelTask(id: JsValue, json: JsValue)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleCancelTask(id: JsValue, json: JsValue)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val taskId = json.at("params.id").asOpt[String].getOrElse("")
     if (taskId.isEmpty) {
       rpcErr(id, A2AErrors.InvalidParams, "missing 'id' param")
@@ -320,7 +320,7 @@ class A2AServerPlugin extends NgBackendCall {
   // one SSE `data:` line wrapping a JSON-RPC response whose result is a StreamResponse (encapsulated by member)
   private def sse(id: JsValue, sr: StreamResponse): ByteString = s"data: ${A2AJsonRpc.ok(id, sr.resultJson).stringify}\n\n".byteString
 
-  private def handleSendStreamingMessage(id: JsValue, json: JsValue, srv: A2AServer, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleSendStreamingMessage(id: JsValue, json: JsValue, srv: A2AServer, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val params = json.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val msgJson = params.select("message").asOpt[JsValue].getOrElse(Json.obj())
     A2AMessage.format.reads(msgJson).asOpt match {
@@ -332,7 +332,7 @@ class A2AServerPlugin extends NgBackendCall {
         val contextId = message.contextId.getOrElse(A2A.newId("ctx"))
         val taskId = A2A.newId("task")
         val artifactId = A2A.newId("art")
-        def chunked(source: Source[ByteString, _]): BackendCallResponse =
+        def chunked(source: Source[ByteString, ?]): BackendCallResponse =
           BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok.chunked(source).as("text/event-stream")), None)
         val workingEvt = sse(id, StreamResponse.OfStatusUpdate(TaskStatusUpdateEvent(taskId, contextId, TaskStatus(TaskState.Working))))
         val completedEvt = sse(id, StreamResponse.OfStatusUpdate(TaskStatusUpdateEvent(taskId, contextId, TaskStatus(TaskState.Completed))))
@@ -341,7 +341,7 @@ class A2AServerPlugin extends NgBackendCall {
             // mark the task working, then stream deltas; persist the completed task when the stream finishes
             store.put(A2ATask(taskId, contextId, TaskStatus(TaskState.Working, None, Some(A2A.nowTimestamp())), history = Seq(message))).map { _ =>
               val acc = new StringBuilder()
-              val deltas: Source[ByteString, _] = chunkSource
+              val deltas: Source[ByteString, ?] = chunkSource
                 .map(chunk => chunk.choices.headOption.flatMap(_.delta.content).getOrElse(""))
                 .filter(_.nonEmpty)
                 .map { txt =>
@@ -386,7 +386,7 @@ class A2AServerPlugin extends NgBackendCall {
   }
 
   // fire push notifications for a terminal task: stores the inline config (if any) and POSTs the StreamResponse({task})
-  private def maybeFirePush(srv: A2AServer, task: A2ATask, params: JsValue)(implicit env: Env, ec: ExecutionContext): Unit = {
+  private def maybeFirePush(srv: A2AServer, task: A2ATask, params: JsValue)(using env: Env, ec: ExecutionContext): Unit = {
     if (srv.agentCard.capabilities.pushNotifications) {
       params.at("configuration.taskPushNotificationConfig").asOpt[JsValue].foreach { cfgJson =>
         val cfg = A2APushConfig.from(cfgJson).copy(taskId = task.id)
@@ -397,7 +397,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleListTasks(id: JsValue, json: JsValue)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleListTasks(id: JsValue, json: JsValue)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val params = json.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val contextId = params.select("contextId").asOpt[String]
     val status = params.select("status").asOpt[String].map(TaskState.apply).filter(_ != TaskState.Unspecified)
@@ -416,7 +416,7 @@ class A2AServerPlugin extends NgBackendCall {
   }
 
   // replay the stored state of a task as SSE events (sync model: no live stream to resume)
-  private def handleSubscribeToTask(id: JsValue, json: JsValue)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleSubscribeToTask(id: JsValue, json: JsValue)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val taskId = json.at("params.id").asOpt[String].getOrElse("")
     if (taskId.isEmpty) {
       rpcErr(id, A2AErrors.InvalidParams, "missing 'id' param")
@@ -434,7 +434,7 @@ class A2AServerPlugin extends NgBackendCall {
 
   private def pushDisabled(srv: A2AServer): Boolean = !srv.agentCard.capabilities.pushNotifications
 
-  private def handleCreatePushConfig(id: JsValue, json: JsValue, srv: A2AServer)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleCreatePushConfig(id: JsValue, json: JsValue, srv: A2AServer)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (pushDisabled(srv)) rpcErr(id, A2AErrors.PushNotificationNotSupported, "push notifications not supported", Some(A2AErrors.errorInfo("PUSH_NOTIFICATION_NOT_SUPPORTED")))
     else {
       val params = json.select("params").asOpt[JsValue].getOrElse(Json.obj())
@@ -444,7 +444,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleGetPushConfig(id: JsValue, json: JsValue, srv: A2AServer)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleGetPushConfig(id: JsValue, json: JsValue, srv: A2AServer)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (pushDisabled(srv)) rpcErr(id, A2AErrors.PushNotificationNotSupported, "push notifications not supported", Some(A2AErrors.errorInfo("PUSH_NOTIFICATION_NOT_SUPPORTED")))
     else {
       val taskId = json.at("params.taskId").asOpt[String].orElse(json.at("params.task_id").asOpt[String]).getOrElse("")
@@ -456,7 +456,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleListPushConfigs(id: JsValue, json: JsValue, srv: A2AServer)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleListPushConfigs(id: JsValue, json: JsValue, srv: A2AServer)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (pushDisabled(srv)) rpcErr(id, A2AErrors.PushNotificationNotSupported, "push notifications not supported", Some(A2AErrors.errorInfo("PUSH_NOTIFICATION_NOT_SUPPORTED")))
     else {
       val taskId = json.at("params.taskId").asOpt[String].orElse(json.at("params.task_id").asOpt[String]).getOrElse("")
@@ -464,7 +464,7 @@ class A2AServerPlugin extends NgBackendCall {
     }
   }
 
-  private def handleDeletePushConfig(id: JsValue, json: JsValue, srv: A2AServer)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def handleDeletePushConfig(id: JsValue, json: JsValue, srv: A2AServer)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (pushDisabled(srv)) rpcErr(id, A2AErrors.PushNotificationNotSupported, "push notifications not supported", Some(A2AErrors.errorInfo("PUSH_NOTIFICATION_NOT_SUPPORTED")))
     else {
       val taskId = json.at("params.taskId").asOpt[String].orElse(json.at("params.task_id").asOpt[String]).getOrElse("")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/agentproxy.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/agentproxy.scala
@@ -1,17 +1,16 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.agents.{AgentConfig, AgentInput, AgentRunConfig}
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.AiPluginsKeys
-import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, InputChatMessage}
+import com.cloud.apim.otoroshi.extensions.aigateway.InputChatMessage
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.security.IdGenerator
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -83,7 +82,7 @@ class AgentProxy extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -101,7 +100,7 @@ class AgentProxy extends NgBackendCall {
     }
   }
 
-  private def call(jsonBody: JsValue, config: AgentProxyConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def call(jsonBody: JsValue, config: AgentProxyConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     println(config.agent.prettify)
     val agent = AgentConfig.from(config.agent)
     val rcfg = AgentRunConfig.from(config.runConfig)
@@ -130,7 +129,7 @@ class AgentProxy extends NgBackendCall {
         val model = agent.model.getOrElse(rcfg.model.getOrElse("agent"))
         Right(BackendCallResponse(NgPluginHttpResponse.fromResult(
           Results.Ok(output.response.openaiJson(model, env))
-            .withHeaders(output.metadata.cacheHeaders.toSeq: _*)
+            .withHeaders(output.metadata.cacheHeaders.toSeq*)
         ), None))
     }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/anthropicproxy.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/anthropicproxy.scala
@@ -1,31 +1,24 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.decorators.ChatClientWithRequestResponseLogging
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.{AiPluginRefsConfig, AiPluginsKeys}
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatClient, ChatPrompt, InputChatMessage}
-import io.azam.ulidj.ULID
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
 import otoroshi.security.IdGenerator
-import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import java.io.File
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths, StandardOpenOption}
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 case class AnthropicStreamResponseState(
   textStarted: AtomicBoolean = new AtomicBoolean(false),
@@ -233,7 +226,7 @@ object AnthropicCompatProxy {
     }
   }
 
-  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val reqId = System.currentTimeMillis
     val jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsonBody, config)
       .applyOnWithOpt(ctx.config.select("override_model").asOptString.filter(_.trim.nonEmpty)) {
@@ -328,7 +321,7 @@ object AnthropicCompatProxy {
                 ))))
               case Right(response) =>
                 Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.anthropicJson(client.computeModel(jsonBody).getOrElse("none"), env))
-                  .withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+                  .withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -344,7 +337,7 @@ object AnthropicCompatProxy {
     }
   }
 
-  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -402,7 +395,7 @@ class AnthropicCompatProxy extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     AnthropicCompatProxy.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/assistantmcp.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/assistantmcp.scala
@@ -1,16 +1,16 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.AssistantConfiguration
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.tools.{ToolCallContext, ToolRegistry}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -170,7 +170,7 @@ class AssistantMcpEndpoint extends NgBackendCall {
     jsonRpcOk(id, Json.obj("tools" -> JsArray(tools)))
   }
 
-  private def toolsCall(id: JsValue, request: JsValue, config: AssistantMcpEndpointConfig)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def toolsCall(id: JsValue, request: JsValue, config: AssistantMcpEndpointConfig)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val params = request.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val toolName = params.select("name").asOpt[String].getOrElse("")
     val arguments = params.select("arguments").asOpt[JsObject].getOrElse(Json.obj())
@@ -210,7 +210,7 @@ class AssistantMcpEndpoint extends NgBackendCall {
     }
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AssistantMcpEndpointConfig.format).getOrElse(AssistantMcpEndpointConfig.default)
     val method = ctx.request.method.toLowerCase()
     if (method != "post") {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/audio.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/audio.scala
@@ -1,17 +1,17 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.FileIO
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.FileIO
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AudioModel
 import com.cloud.apim.otoroshi.extensions.aigateway.{AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.http._
-import play.api.libs.json._
+import play.api.http.*
+import play.api.libs.json.*
 import play.api.mvc.{RequestHeader, Result, Results}
 import play.core.parsers.Multipart
 
@@ -52,7 +52,7 @@ object OpenAICompatTextToSpeechConfig {
     }
   }
 
-  def getProvidersMap(config: OpenAICompatTextToSpeechConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, AudioModel], Map[String, AudioModel]) = {
+  def getProvidersMap(config: OpenAICompatTextToSpeechConfig)(using ec: ExecutionContext, env: Env): (Map[String, AudioModel], Map[String, AudioModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.audioModel(ref))
     val providersByName = providers.map { provider =>
@@ -63,7 +63,7 @@ object OpenAICompatTextToSpeechConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatTextToSpeechConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatTextToSpeechConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -101,7 +101,7 @@ object OpenAICompatTextToSpeechConfig {
 }
 
 object OpenAICompatTextToSpeech {
-  def handleRequest(config: OpenAICompatTextToSpeechConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatTextToSpeechConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val _jsonBody = bodyRaw.utf8String.parseJson
@@ -157,7 +157,7 @@ class OpenAICompatTextToSpeech extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatTextToSpeechConfig.format).getOrElse(OpenAICompatTextToSpeechConfig.default)
     OpenAICompatTextToSpeech.handleRequest(config, ctx)
   }
@@ -201,7 +201,7 @@ object OpenAICompatSpeechToTextConfig {
     }
   }
 
-  def getProvidersMap(config: OpenAICompatSpeechToTextConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, AudioModel], Map[String, AudioModel]) = {
+  def getProvidersMap(config: OpenAICompatSpeechToTextConfig)(using ec: ExecutionContext, env: Env): (Map[String, AudioModel], Map[String, AudioModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.audioModel(ref))
     val providersByName = providers.map { provider =>
@@ -212,7 +212,7 @@ object OpenAICompatSpeechToTextConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatSpeechToTextConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatSpeechToTextConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -250,7 +250,7 @@ object OpenAICompatSpeechToTextConfig {
 }
 
 object OpenAICompatSpeechToText {
-  def handleRequest(config: OpenAICompatSpeechToTextConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatSpeechToTextConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     Multipart.multipartParser(
       config.maxSizeUpload,
@@ -345,14 +345,14 @@ class OpenAICompatSpeechToText extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatSpeechToTextConfig.format).getOrElse(OpenAICompatSpeechToTextConfig.default)
     OpenAICompatSpeechToText.handleRequest(config, ctx)
   }
 }
 
 object OpenAICompatTranslation {
-  def handleRequest(config: OpenAICompatSpeechToTextConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatSpeechToTextConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     Multipart.multipartParser(
       config.maxSizeUpload,
@@ -447,7 +447,7 @@ class OpenAICompatTranslation extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatSpeechToTextConfig.format).getOrElse(OpenAICompatSpeechToTextConfig.default)
     OpenAICompatTranslation.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/config.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/config.scala
@@ -1,13 +1,13 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, InputChatMessage}
+import com.cloud.apim.otoroshi.extensions.aigateway.InputChatMessage
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.env.Env
 import otoroshi.next.plugins.api.NgPluginConfig
 import otoroshi.utils.RegexPool
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.typedmap.TypedKey
 
 import scala.concurrent.ExecutionContext
@@ -21,7 +21,7 @@ object AiPluginsKeys {
 
 case class AiPromptRequestConfig(ref: String = "", _prompt: String = "", promptRef: Option[String] = None, contextRef: Option[String] = None, extractor: Option[String] = None) extends NgPluginConfig {
   def json: JsValue = AiPromptRequestConfig.format.writes(this)
-  def preChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def preChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -33,7 +33,7 @@ case class AiPromptRequestConfig(ref: String = "", _prompt: String = "", promptR
       }
     }
   }
-  def postChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def postChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -45,7 +45,7 @@ case class AiPromptRequestConfig(ref: String = "", _prompt: String = "", promptR
       }
     }
   }
-  def prompt(implicit env: Env): String = promptRef match {
+  def prompt(using env: Env): String = promptRef match {
     case None => _prompt
     case Some(ref) => env.adminExtensions.extension[AiExtension] match {
       case None => _prompt
@@ -226,7 +226,7 @@ object AiPluginRefsConfig {
       case Success(value) => JsSuccess(value)
     }
   }
-  def getProvidersMap(config: AiPluginRefsConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, AiProvider], Map[String, AiProvider]) = {
+  def getProvidersMap(config: AiPluginRefsConfig)(using ec: ExecutionContext, env: Env): (Map[String, AiProvider], Map[String, AiProvider]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.provider(ref))
     val providersByName = providers.map { provider =>
@@ -237,7 +237,7 @@ object AiPluginRefsConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: AiPluginRefsConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: AiPluginRefsConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/contenttomarkdown.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/contenttomarkdown.scala
@@ -1,14 +1,14 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.KreuzbergHelper
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -68,7 +68,7 @@ class ContentToMarkdownPlugin extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (!KreuzbergHelper.canExecuteKreuzberg) {
       return Left(NgProxyEngineError.NgResultProxyEngineError(
         Results.InternalServerError(Json.obj("error" -> KreuzbergHelper.errorMsg))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/contextvalidator.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/contextvalidator.scala
@@ -4,8 +4,8 @@ import com.cloud.apim.otoroshi.extensions.aigateway.plugins.AiPromptRequestConfi
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt}
 import otoroshi.env.Env
 import otoroshi.gateway.Errors
-import otoroshi.next.plugins.api._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Results
@@ -33,7 +33,7 @@ class AiContextValidator extends NgAccessValidator {
     ().vfuture
   }
 
-  private def validate(ctx: NgAccessContext, config: AiPromptRequestConfig)(implicit env: Env, ec: ExecutionContext): Future[Boolean] = {
+  private def validate(ctx: NgAccessContext, config: AiPromptRequestConfig)(using env: Env, ec: ExecutionContext): Future[Boolean] = {
     env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {
       case None => false.vfuture // TODO: log it
       case Some(provider) => provider.getChatClient() match {
@@ -43,7 +43,7 @@ class AiContextValidator extends NgAccessValidator {
             ChatMessage.input("system", config.prompt, None, Json.obj()),
             ChatMessage.input("user", ctx.json.stringify, None, Json.obj()),
           ) ++ config.postChatMessages), ctx.attrs, Json.obj()).map {
-            case Left(err) => false // TODO: log it
+            case Left(_) => false // TODO: log it
             case Right(resp) => {
               val content = resp.headGeneration.message.content
               config.extractor match {
@@ -72,7 +72,7 @@ class AiContextValidator extends NgAccessValidator {
     }
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     val config = ctx.cachedConfig(internalName)(AiPromptRequestConfig.format).getOrElse(AiPromptRequestConfig())
     validate(ctx, config) flatMap {
       case true => NgAccess.NgAllowed.vfuture

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/embeddings.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/embeddings.scala
@@ -1,15 +1,15 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.EmbeddingClientInputOptions
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.EmbeddingModel
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -48,7 +48,7 @@ object OpenAICompatEmbeddingConfig {
       case Success(value) => JsSuccess(value)
     }
   }
-  def getProvidersMap(config: OpenAICompatEmbeddingConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, EmbeddingModel], Map[String, EmbeddingModel]) = {
+  def getProvidersMap(config: OpenAICompatEmbeddingConfig)(using ec: ExecutionContext, env: Env): (Map[String, EmbeddingModel], Map[String, EmbeddingModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.embeddingModel(ref))
     val providersByName = providers.map { provider =>
@@ -59,7 +59,7 @@ object OpenAICompatEmbeddingConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatEmbeddingConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatEmbeddingConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -97,7 +97,7 @@ object OpenAICompatEmbeddingConfig {
 }
 
 object OpenAICompatEmbedding {
-  def handleRequest(config: OpenAICompatEmbeddingConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatEmbeddingConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val _jsonBody = bodyRaw.utf8String.parseJson
@@ -151,7 +151,7 @@ class OpenAICompatEmbedding extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatEmbeddingConfig.format).getOrElse(OpenAICompatEmbeddingConfig.default)
     OpenAICompatEmbedding.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/imagesgen.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/imagesgen.scala
@@ -1,17 +1,17 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.FileIO
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AudioModel, ImageModel}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.FileIO
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.ImageModel
 import com.cloud.apim.otoroshi.extensions.aigateway.{ImageFile, ImageModelClientEditionInputOptions, ImageModelClientGenerationInputOptions}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.http.HttpErrorHandler
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{RequestHeader, Result, Results}
 import play.core.parsers.Multipart
 
@@ -64,7 +64,7 @@ object OpenAiCompatImagesGenConfig {
     }
   }
 
-  def getProvidersMap(config: OpenAiCompatImagesGenConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, ImageModel], Map[String, ImageModel]) = {
+  def getProvidersMap(config: OpenAiCompatImagesGenConfig)(using ec: ExecutionContext, env: Env): (Map[String, ImageModel], Map[String, ImageModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.imageModel(ref))
     val providersByName = providers.map { provider =>
@@ -75,7 +75,7 @@ object OpenAiCompatImagesGenConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAiCompatImagesGenConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAiCompatImagesGenConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -113,7 +113,7 @@ object OpenAiCompatImagesGenConfig {
 }
 
 object OpenAICompatImagesGen {
-  def handleRequest(config: OpenAiCompatImagesGenConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAiCompatImagesGenConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val _jsonBody = bodyRaw.utf8String.parseJson
@@ -174,7 +174,7 @@ class OpenAICompatImagesGen extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAiCompatImagesGenConfig.format).getOrElse(OpenAiCompatImagesGenConfig.default)
     OpenAICompatImagesGen.handleRequest(config, ctx)
   }
@@ -219,7 +219,7 @@ object OpenAICompatImagesEditConfig {
     }
   }
 
-  def getProvidersMap(config: OpenAICompatImagesEditConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, ImageModel], Map[String, ImageModel]) = {
+  def getProvidersMap(config: OpenAICompatImagesEditConfig)(using ec: ExecutionContext, env: Env): (Map[String, ImageModel], Map[String, ImageModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.imageModel(ref))
     val providersByName = providers.map { provider =>
@@ -230,7 +230,7 @@ object OpenAICompatImagesEditConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatImagesEditConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatImagesEditConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -269,7 +269,7 @@ object OpenAICompatImagesEditConfig {
 
 
 object OpenAICompatImagesEdit {
-  def handleRequest(config: OpenAICompatImagesEditConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatImagesEditConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     Multipart.multipartParser(
       config.maxSizeUpload,
@@ -354,7 +354,7 @@ class OpenAICompatImagesEdit extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatImagesEditConfig.format).getOrElse(OpenAICompatImagesEditConfig.default)
     OpenAICompatImagesEdit.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/llmresponse.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/llmresponse.scala
@@ -1,14 +1,14 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt, InputChatMessage}
 import otoroshi.el.GlobalExpressionLanguage
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 
 case class LlmResponseConfig(ref: String = "", _prompt: String = "", promptRef: Option[String] = None, contextRef: Option[String] = None) extends NgPluginConfig {
   def json: JsValue = LlmResponseConfig.format.writes(this)
-  def promptBeforeEl(implicit env: Env): String = promptRef match {
+  def promptBeforeEl(using env: Env): String = promptRef match {
     case None => _prompt
     case Some(ref) => env.adminExtensions.extension[AiExtension] match {
       case None => _prompt
@@ -26,7 +26,7 @@ case class LlmResponseConfig(ref: String = "", _prompt: String = "", promptRef: 
       }
     }
   }
-  def preChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def preChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -38,7 +38,7 @@ case class LlmResponseConfig(ref: String = "", _prompt: String = "", promptRef: 
       }
     }
   }
-  def postChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def postChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -140,7 +140,7 @@ class LlmResponseEndpoint extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(LlmResponseConfig.format).getOrElse(LlmResponseConfig.default)
     env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {
       case None => Left(NgProxyEngineError.NgResultProxyEngineError(Results.InternalServerError(Json.obj("error" -> "provider not found")))).vfuture // TODO: rewrite error

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/llmstxt.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/llmstxt.scala
@@ -1,18 +1,18 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
@@ -123,7 +123,7 @@ class MarkdownAcceptPlugin extends NgBackendCall {
   override def callBackend(
     ctx: NgbBackendCallContext,
     delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]]
-  )(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  )(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
 
     val config = ctx.cachedConfig(internalName)(MarkdownAcceptConfig.format).getOrElse(MarkdownAcceptConfig.default)
     val acceptHeader = ctx.request.headers.get("Accept")
@@ -190,12 +190,12 @@ class MarkdownAcceptPlugin extends NgBackendCall {
   private def buildVariantRequest(
     ctx: NgbBackendCallContext,
     variantPath: String
-  )(implicit env: Env): play.api.libs.ws.WSRequest = {
+  )(using env: Env): play.api.libs.ws.WSRequest = {
     val url = s"${ctx.backend.baseUrl}$variantPath"
     val headers = ctx.request.headers.toSeq
 
     env.Ws.url(url)
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withMethod(ctx.request.method)
       .withRequestTimeout(ctx.route.backend.client.callTimeout.millis)
   }
@@ -211,7 +211,7 @@ class MarkdownAcceptPlugin extends NgBackendCall {
         contentLength,
         response.contentType.some
       )
-    ).withHeaders(response.headers.flatMap { case (k, vs) => vs.map(v => (k, v)) }.toSeq: _*)
+    ).withHeaders(response.headers.flatMap { case (k, vs) => vs.map(v => (k, v)) }.toSeq*)
 
     BackendCallResponse(NgPluginHttpResponse.fromResult(result), None)
   }
@@ -219,7 +219,7 @@ class MarkdownAcceptPlugin extends NgBackendCall {
   private def fetchVariant(
     ctx: NgbBackendCallContext,
     variantPath: String
-  )(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  )(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     buildVariantRequest(ctx, variantPath)
       .stream()
       .map { response =>
@@ -240,7 +240,7 @@ class MarkdownAcceptPlugin extends NgBackendCall {
     delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]],
     variants: Seq[String],
     cacheInfoOpt: Option[(Cache[String, Option[String]], String)]
-  )(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  )(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
 
     // Check if we have a recent server error cached
     // Use cache key from cacheInfoOpt or build it for error cache lookup

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/mcp.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/mcp.scala
@@ -1,43 +1,41 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.actor.{Actor, ActorRef, PoisonPill, Props}
-import akka.http.scaladsl.model.Uri
-import akka.stream.scaladsl.{Flow, Sink, Source, SourceQueueWithComplete}
-import akka.stream.{Materializer, OverflowStrategy}
-import akka.util.ByteString
+import org.apache.pekko.actor.{Actor, ActorRef, PoisonPill, Props}
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.scaladsl.{Flow, Sink, Source, SourceQueueWithComplete}
+import org.apache.pekko.stream.{Materializer, OverflowStrategy}
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatMessage
-import com.cloud.apim.otoroshi.extensions.aigateway.agents.InlineFunction
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{GuardrailItem, GuardrailResult, Guardrails}
-import com.cloud.apim.otoroshi.extensions.aigateway.entities.{LlmToolFunction, McpConnector, McpConnectorRules, McpConnectorTransport, McpConnectorTransportKind, McpRegistryConfig, McpSupport, McpVirtualServer}
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.{McpConnector, McpConnectorRules, McpConnectorTransport, McpConnectorTransportKind, McpSupport, McpVirtualServer}
 import dev.langchain4j.agent.tool.ToolSpecification
-import dev.langchain4j.mcp.client.{McpBlobResourceContents, McpResourceContents, McpTextResourceContents}
-import dev.langchain4j.model.chat.request.json.JsonSchemaElement
+import dev.langchain4j.mcp.client.McpResourceContents
 import otoroshi.auth.OAuth2ModuleConfig
 import otoroshi.env.Env
 import otoroshi.events.AuditEvent
-import otoroshi.models.{InHeader, InQueryParam, JWKSAlgoSettings, JwtTokenLocation, LocalJwtVerifier}
-import otoroshi.next.plugins.{OIDCAuthToken, OIDCAuthTokenConfig, OIDCJwtVerifierConfig}
+import otoroshi.models.{InHeader, InQueryParam, JWKSAlgoSettings, LocalJwtVerifier}
+import otoroshi.next.plugins.{OIDCAuthToken, OIDCAuthTokenConfig}
 import otoroshi.next.models.{NgPluginInstance, NgPluginInstanceConfig}
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.next.workflow.WorkflowRun
 import otoroshi.security.IdGenerator
 import otoroshi.utils.TypedMap
 import otoroshi.utils.http.RequestImplicits.EnhancedRequestHeader
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.http.websocket.Message
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.streams.ActorFlow
 import play.api.libs.ws.DefaultBodyWritables.writeableOf_urlEncodedSimpleForm
+import play.api.libs.ws.WSBodyWritables.given
 import play.api.libs.typedmap.TypedKey
 import play.api.mvc.{Result, Results}
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong, AtomicReference}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 object McpOAuthFilterUtils {
@@ -59,7 +57,7 @@ object McpOAuthFilterUtils {
     if (parts.length < 2) Set.empty[String] else scopesFromClaims(parts(1).decodeBase64.parseJson)
   }.getOrElse(Set.empty)
 
-  def unauthorizedResult(ctx: NgAccessContext, config: McpProxyEndpointConfig, oidcModule: OAuth2ModuleConfig)(implicit env: Env, ec: ExecutionContext): Result = {
+  def unauthorizedResult(ctx: NgAccessContext, config: McpProxyEndpointConfig, oidcModule: OAuth2ModuleConfig)(using env: Env, ec: ExecutionContext): Result = {
     val realmName = oidcModule.cookieSuffix(ctx.route.legacy)
     val authPrmUrl = config.authPrmUrl.getOrElse(s"${ctx.request.theProtocol}://${ctx.request.theHost}/.well-known/oauth-protected-resource")
     Results.Status(401)(Json.obj("error" -> "unauthorized"))
@@ -70,7 +68,7 @@ object McpOAuthFilterUtils {
   // RFC 7662 token introspection, implemented locally so it works against the published Otoroshi
   // 17.11.0 (no dependency on the core `introspectTokenSafe`). Mirrors the legacy core introspection.
   // TODO(otoroshi with introspectTokenSafe published): delete this and call oidcModule.introspectTokenSafe.
-  def introspectToken(oidcModule: OAuth2ModuleConfig, token: String)(implicit env: Env, ec: ExecutionContext): Future[Option[JsValue]] = {
+  def introspectToken(oidcModule: OAuth2ModuleConfig, token: String)(using env: Env, ec: ExecutionContext): Future[Option[JsValue]] = {
     val clientSecret = Option(oidcModule.clientSecret).filterNot(_.trim.isEmpty)
     val builder      = env.MtlsWs.url(oidcModule.introspectionUrl, oidcModule.mtlsConfig)
     val future       = if (oidcModule.useJson) {
@@ -82,7 +80,7 @@ object McpOAuthFilterUtils {
       builder.post(
         Map("token" -> token, "client_id" -> oidcModule.clientId) ++
           clientSecret.toSeq.map(s => ("client_secret" -> s))
-      )(writeableOf_urlEncodedSimpleForm)
+      )(using writeableOf_urlEncodedSimpleForm)
     }
     future
       .map(resp => if (resp.status == 200 && (resp.json \ "active").asOpt[Boolean].getOrElse(false)) Some(resp.json) else None)
@@ -92,7 +90,7 @@ object McpOAuthFilterUtils {
   // Audience binding (RFC 8707): the token `aud` claim (string OR array) must match this MCP server's
   // URL, mirroring the core getSession check but array-aware. Used locally until the core patch ships.
   // TODO(otoroshi with array-aware getSession published): remove and rely on getSession validateAudience.
-  def audienceMatches(token: String, ctx: NgAccessContext)(implicit env: Env): Boolean = {
+  def audienceMatches(token: String, ctx: NgAccessContext)(using env: Env): Boolean = {
     Try {
       val parts = token.split("\\.")
       if (parts.length < 2) {
@@ -113,13 +111,13 @@ object McpOAuthFilterUtils {
     }.getOrElse(false)
   }
 
-  def access(ctx: NgAccessContext, internalName: String)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  def access(ctx: NgAccessContext, internalName: String)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     val config = ctx.cachedConfig(internalName)(McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default).resolve()
     config.authModuleRef match {
       case None if !config.enforceOAuth => NgAccess.NgAllowed.vfuture
-      case None if config.enforceOAuth  => NgAccess.NgDenied(Results.BadRequest(Json.obj("error" -> "no auth. module setup"))).vfuture
+      case None                            => NgAccess.NgDenied(Results.BadRequest(Json.obj("error" -> "no auth. module setup"))).vfuture
       case Some(_) if !config.enforceOAuth => NgAccess.NgAllowed.vfuture
-      case Some(authModuleId) if config.enforceOAuth =>
+      case Some(authModuleId)              =>
         env.proxyState.authModule(authModuleId) match {
           case None    => NgAccess.NgDenied(Results.BadRequest(Json.obj("error" -> "auth. module not found"))).vfuture
           case Some(m) =>
@@ -162,7 +160,7 @@ object McpOAuthFilterUtils {
                           Some(token)
                         )
                         .map {
-                          case Left(result) => NgAccess.NgDenied(customResult)
+                          case Left(_) => NgAccess.NgDenied(customResult)
                           case Right(r)     => r
                         }
                     }
@@ -192,7 +190,7 @@ object McpOAuthFilterUtils {
                         ctx.user,
                         ctx.attrs.get(otoroshi.plugins.Keys.ElCtxKey).getOrElse(Map.empty),
                         ctx.attrs
-                      ) { t =>
+                      ) { _ =>
                         ctx.attrs.put(McpUserAuthTokenKey -> token)
                         ctx.attrs.put(McpGrantedScopesKey -> scopesFromJwt(token))
                         // Audience binding (RFC 8707) done locally so it accepts `aud` as a string OR an
@@ -217,7 +215,7 @@ object McpOAuthFilterUtils {
                         }
                       }
                       .map {
-                        case Left(result) => NgAccess.NgDenied(customResult)
+                        case Left(_) => NgAccess.NgDenied(customResult)
                         case Right(r)     => r
                       }
                 }
@@ -280,7 +278,7 @@ case class McpStaticResource(
 
   // contents entry returned by resources/read for this resource (a single content block).
   // emitAudit gates the McpResourceFetchAudit event for the outbound url fetch (metrics are always recorded).
-  def read(attrs: TypedMap, allowedHosts: Seq[String], emitAudit: Boolean = false)(implicit env: Env, ec: ExecutionContext): Future[JsObject] = {
+  def read(attrs: TypedMap, allowedHosts: Seq[String], emitAudit: Boolean = false)(using env: Env, ec: ExecutionContext): Future[JsObject] = {
     val base = Json.obj("uri" -> uri)
     url match {
       case Some(rawUrl) =>
@@ -294,21 +292,21 @@ case class McpStaticResource(
           if (forwardAuth) ev.replace("{input_token}", inputToken) else ev
         }
         val finalUrl = render(rawUrl)
-        val finalHeaders = headers.mapValues(render).toSeq
+        val finalHeaders = headers.view.mapValues(render).toSeq
         if (!hostAllowed(finalUrl, allowedHosts)) {
           McpStaticResource.markFetchMetrics(0L, isError = true)
           if (emitAudit) McpStaticResource.emitFetch(uri, finalUrl, 0L, None, Some("host not allowed"), attrs)
           Future.successful(withMime(base, None) ++ Json.obj("text" -> s"fetching resource is not allowed for this host") ++ metaJson)
         } else {
           val start = System.currentTimeMillis()
-          env.Ws.url(finalUrl).withHttpHeaders(finalHeaders: _*).withRequestTimeout(timeout).get().map { resp =>
+          env.Ws.url(finalUrl).withHttpHeaders(finalHeaders*).withRequestTimeout(timeout).get().map { resp =>
             val dur = System.currentTimeMillis() - start
             val isErr = resp.status >= 400
             McpStaticResource.markFetchMetrics(dur, isErr)
             if (emitAudit) McpStaticResource.emitFetch(uri, finalUrl, dur, Some(resp.status), if (isErr) Some(s"status ${resp.status}") else None, attrs)
             val ct = Option(resp.contentType)
             if (urlAs == "blob") withMime(base, ct) ++ Json.obj("blob" -> resp.bodyAsBytes.encodeBase64.utf8String) ++ metaJson
-            else withMime(base, ct) ++ Json.obj("text" -> resp.body) ++ metaJson
+            else withMime(base, ct) ++ Json.obj("text" -> (resp.body: String)) ++ metaJson
           }.recover { case e =>
             val dur = System.currentTimeMillis() - start
             McpStaticResource.markFetchMetrics(dur, isError = true)
@@ -330,7 +328,7 @@ object McpStaticResource {
 
   // Real-time metrics for the outbound fetch of a managed resource served from a `url` (always on when env
   // metrics are enabled, independent of the audit flag). Namespaced apart from mcp.client.* (connectors).
-  def markFetchMetrics(durationMs: Long, isError: Boolean)(implicit env: Env): Unit = {
+  def markFetchMetrics(durationMs: Long, isError: Boolean)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     env.metrics.counterInc("mcp.resource.fetch.calls")
     if (isError) env.metrics.counterInc("mcp.resource.fetch.errors")
@@ -339,7 +337,7 @@ object McpStaticResource {
 
   // Audit event for the outbound fetch of a managed resource (mirrors McpClientAudit but for the env.Ws fetch
   // that does not go through an McpConnector). Gated by the virtual server's emit_audit_events flag.
-  def emitFetch(uri: String, url: String, duration: Long, httpStatus: Option[Int], error: Option[String], attrs: TypedMap)(implicit env: Env): Unit = {
+  def emitFetch(uri: String, url: String, duration: Long, httpStatus: Option[Int], error: Option[String], attrs: TypedMap)(using env: Env): Unit = {
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
     val route = attrs.get(otoroshi.next.plugins.Keys.RouteKey)
@@ -462,7 +460,7 @@ case class McpStaticPrompt(
     meta.map(m => Json.obj("_meta" -> m)).getOrElse(Json.obj())
 
   // prompts/get response payload (description + rendered messages)
-  def getJson(args: Map[String, String], attrs: TypedMap)(implicit env: Env): JsObject = {
+  def getJson(args: Map[String, String], attrs: TypedMap)(using env: Env): JsObject = {
     def render(t: String): String = {
       val withArgs = args.foldLeft(t) { case (acc, (k, v)) => acc.replace("{{" + k + "}}", v) }
       withArgs.evaluateEl(attrs)
@@ -784,7 +782,7 @@ case class McpProxyEndpointConfig(
 
   // When `serverRef` points to an existing McpVirtualServer, start from its config and overlay these inline
   // overrides. Otherwise return this config unchanged (full backward compatibility for ref-less routes).
-  def resolve()(implicit env: Env): McpProxyEndpointConfig = {
+  def resolve()(using env: Env): McpProxyEndpointConfig = {
     serverRef.flatMap(r => env.adminExtensions.extension[AiExtension].get.states.mcpVirtualServer(r)) match {
       case Some(server) => server.config.overriddenBy(this)
       case None => this
@@ -833,7 +831,7 @@ case class McpProxyEndpointConfig(
    * capability only when at least one connector exposes something in it. Local workflow
    * functions (`functionRefs`) count as tools.
    */
-  def computeCapabilities(attrs: TypedMap, includeLogging: Boolean)(implicit env: Env, ec: ExecutionContext): Future[JsObject] = {
+  def computeCapabilities(attrs: TypedMap, includeLogging: Boolean)(using env: Env, ec: ExecutionContext): Future[JsObject] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val hasLocalFunctions = functionRefs.flatMap(r => ext.states.toolFunction(r)).nonEmpty
     val connectors = mcpRefs.flatMap(r => ext.states.mcpConnector(r)).map(applyFiltersTo)
@@ -1162,7 +1160,7 @@ object McpProxyEndpointConfig {
         opaqueToken = json.select("opaque_token").asOptBoolean.getOrElse(false),
         useIntrospection = json.select("use_introspection").asOptBoolean.getOrElse(false),
         toolScopes = json.select("tool_scopes").asOpt[Map[String, Seq[String]]].orElse(
-          json.select("tool_scopes").asOpt[Map[String, String]].map(_.mapValues(_.split(",").map(_.trim).toSeq)),
+          json.select("tool_scopes").asOpt[Map[String, String]].map(_.view.mapValues(_.split(",").map(_.trim).toSeq).toMap),
         ).getOrElse(Map.empty),
         toolCacheTtls = json.select("tool_cache_ttls").asOpt[Map[String, Long]].getOrElse(Map.empty),
         toolRateLimits = json.select("tool_rate_limits").asOpt[Map[String, Long]].getOrElse(Map.empty),
@@ -1183,13 +1181,13 @@ object McpProxyEndpointConfig {
         excludeResourceTemplateUris = json.select("exclude_resource_template_uris").asOpt[Seq[String]].getOrElse(Seq.empty),
         includePrompts = json.select("include_prompts").asOpt[Seq[String]].getOrElse(Seq.empty),
         excludePrompts = json.select("exclude_prompts").asOpt[Seq[String]].getOrElse(Seq.empty),
-        allowRules = json.select("allow_rules").asOpt(McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
-        disallowRules = json.select("disallow_rules").asOpt(McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
+        allowRules = json.select("allow_rules").asOpt(using McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
+        disallowRules = json.select("disallow_rules").asOpt(using McpConnectorRules.format).getOrElse(McpConnectorRules.empty),
         resources = json.select("resources").asOpt[Seq[JsValue]].getOrElse(Seq.empty).flatMap(v => McpStaticResource.format.reads(v).asOpt),
         resourceFetchAllowedHosts = json.select("resource_fetch_allowed_hosts").asOpt[Seq[String]].getOrElse(Seq.empty),
         prompts = json.select("prompts").asOpt[Seq[JsValue]].getOrElse(Seq.empty).flatMap(v => McpStaticPrompt.format.reads(v).asOpt),
-        overlays = json.select("overlays").asOpt(McpItemOverlays.format).getOrElse(McpItemOverlays.empty),
-        zeroTrust = json.select("zero_trust").asOpt(McpZeroTrustConfig.format).getOrElse(McpZeroTrustConfig.empty),
+        overlays = json.select("overlays").asOpt(using McpItemOverlays.format).getOrElse(McpItemOverlays.empty),
+        zeroTrust = json.select("zero_trust").asOpt(using McpZeroTrustConfig.format).getOrElse(McpZeroTrustConfig.empty),
       )
     } match {
       case Failure(exception) => JsError(exception.getMessage)
@@ -1211,7 +1209,7 @@ object McpAuditHelper {
 
   // Real-time metrics for the MCP server/exposition side (always on when env metrics are enabled,
   // independent of the opt-in `emit_audit_events`). Flat metric names with the method encoded in the name.
-  def markMetrics(method: String, durationMs: Long, isError: Boolean)(implicit env: Env): Unit = {
+  def markMetrics(method: String, durationMs: Long, isError: Boolean)(using env: Env): Unit = {
     if (!env.metricsEnabled) return
     val m = method.replace('/', '.')
     env.metrics.counterInc("mcp.server.calls")
@@ -1232,7 +1230,7 @@ object McpAuditHelper {
     error: Option[String],
     attrs: TypedMap,
     response: JsValue = JsNull
-  )(implicit env: Env): Unit = {
+  )(using env: Env): Unit = {
     val user = attrs.get(otoroshi.plugins.Keys.UserKey)
     val apikey = attrs.get(otoroshi.plugins.Keys.ApiKeyKey)
     val route = attrs.get(otoroshi.next.plugins.Keys.RouteKey)
@@ -1292,12 +1290,12 @@ object McpToolPinning {
     canonicalize(relevant).sha256
   }
 
-  private def pinKey(ident: String, epoch: Long, tool: String)(implicit env: Env): String =
+  private def pinKey(ident: String, epoch: Long, tool: String)(using env: Env): String =
     s"${env.storageRoot}:llmext:mcp:pin:$epoch:${ident.sha256}:$tool"
 
   // TOFU check: an explicit pinned hash (config) is authoritative; otherwise the first sighting is pinned in
   // the datastore and subsequent sightings are compared against it.
-  def check(z: McpZeroTrustConfig, ident: String, toolJson: JsObject)(implicit env: Env, ec: ExecutionContext): Future[PinVerdict] = {
+  def check(z: McpZeroTrustConfig, ident: String, toolJson: JsObject)(using env: Env, ec: ExecutionContext): Future[PinVerdict] = {
     val tool = (toolJson \ "name").asOpt[String].getOrElse("")
     val fp = fingerprint(toolJson)
     z.pinnedHashes.get(tool) match {
@@ -1319,7 +1317,7 @@ object McpToolPinning {
 // description or a tool result), sourced from an explicit list of GuardrailItems instead of a provider's
 // guardrails. Short-circuits on the first Denied; an erroring guardrail is skipped (never blocks).
 object McpZeroTrust {
-  def scan(items: Seq[GuardrailItem], text: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[GuardrailResult] = {
+  def scan(items: Seq[GuardrailItem], text: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[GuardrailResult] = {
     val msg = ChatMessage.userStrInput(text)
     def loop(seq: Seq[GuardrailItem]): Future[GuardrailResult] = seq.headOption match {
       case None => Future.successful(GuardrailResult.GuardrailPass)
@@ -1375,7 +1373,7 @@ object McpRedaction {
 // Emits a correlated audit/analytics event (+ metrics) whenever a zero-trust control fires. Routes through the
 // existing data-exporter pipeline (SIEM/Kafka/ES/...) like McpAudit. `blocked` distinguishes monitor vs enforce.
 object McpZeroTrustAudit {
-  def alert(kind: String, tool: String, detail: JsObject, blocked: Boolean, attrs: TypedMap)(implicit env: Env): Unit = {
+  def alert(kind: String, tool: String, detail: JsObject, blocked: Boolean, attrs: TypedMap)(using env: Env): Unit = {
     if (env.metricsEnabled) {
       env.metrics.counterInc(s"mcp.zerotrust.$kind.alerts")
       if (blocked) env.metrics.counterInc(s"mcp.zerotrust.$kind.blocks")
@@ -1412,7 +1410,7 @@ object McpProxyLogic {
   // Meta connector exposing the 5 virtualization tools (list_servers / list_tools / get_tool_schema /
   // search_tools / execute) - same behavior as a Meta connector. Local functions stay listed directly,
   // and resources/prompts are not affected.
-  private def toolConnectors(config: McpProxyEndpointConfig)(implicit env: Env): Seq[McpConnector] = {
+  private def toolConnectors(config: McpProxyEndpointConfig)(using env: Env): Seq[McpConnector] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     if (config.exposeAsMeta) {
       Seq(McpConnector(
@@ -1429,7 +1427,7 @@ object McpProxyLogic {
     }
   }
 
-  def toolsList(config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
+  def toolsList(config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val functions = config.functionRefs.flatMap(r => ext.states.toolFunction(r))
     val mcpConnectors = toolConnectors(config)
@@ -1472,7 +1470,7 @@ object McpProxyLogic {
 
   // Applies the two list-time zero-trust controls (A. pinning, B. description scan) to the tool list. A tool is
   // dropped only when the corresponding `*Enforce` flag is on; otherwise it stays and only an alert is emitted.
-  private def applyZeroTrustToList(config: McpProxyEndpointConfig, tools: Seq[JsValue], attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
+  private def applyZeroTrustToList(config: McpProxyEndpointConfig, tools: Seq[JsValue], attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
     val z = config.zeroTrust
     if (!z.pinningEnabled && !z.scanDescriptions) Future.successful(tools)
     else {
@@ -1514,7 +1512,7 @@ object McpProxyLogic {
   }
 
   // Per-tool, per-consumer fixed-window (60s) rate limit, backed by the shared datastore (cluster-wide).
-  private def rateLimitAllows(config: McpProxyEndpointConfig, name: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Boolean] = {
+  private def rateLimitAllows(config: McpProxyEndpointConfig, name: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Boolean] = {
     val limit = config.toolRateLimits.get(name).orElse(config.toolRateLimits.get("*")).getOrElse(0L)
     if (limit <= 0L) Future.successful(true)
     else {
@@ -1530,7 +1528,7 @@ object McpProxyLogic {
   // results are cached; the key includes the config identity to avoid cross-server collisions. The cached
   // value is the already-secured payload (post result-scan + redaction), so cache hits stay clean and the
   // guardrails don't re-run on every hit.
-  private def cachedCallTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
+  private def cachedCallTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
     val ttl = config.toolCacheTtls.get(name).orElse(config.toolCacheTtls.get("*")).getOrElse(0L)
     if (ttl <= 0L) securedCallTool(config, name, arguments, attrs)
     else {
@@ -1557,7 +1555,7 @@ object McpProxyLogic {
 
   // Executes the tool then applies the two result-time zero-trust controls (B. result guardrail scan,
   // C. result redaction). A scan denial under enforce returns Left (blocked, never cached).
-  private def securedCallTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
+  private def securedCallTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
     val z = config.zeroTrust
     callToolInternal(config, name, arguments, attrs).flatMap {
       case Right(payload) =>
@@ -1582,7 +1580,7 @@ object McpProxyLogic {
   // At call time (defense in depth): if any list-time control is in enforce mode, the tool must still be a
   // member of the secured tools/list. This blocks direct calls to a tool that pinning or a description
   // guardrail removed — even from a client that never issued tools/list.
-  private def pinningCallCheck(config: McpProxyEndpointConfig, name: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Option[String]] = {
+  private def pinningCallCheck(config: McpProxyEndpointConfig, name: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Option[String]] = {
     val z = config.zeroTrust
     val enforcesListMembership = (z.pinningEnabled && z.pinningEnforce) || (z.scanDescriptions && z.guardrailsEnforce)
     if (!enforcesListMembership) Future.successful(None)
@@ -1595,7 +1593,7 @@ object McpProxyLogic {
   // Resolves and executes a tool call. Left = unknown tool / denied, Right = the result payload. Pipeline:
   // scope→tool authorization → zero-trust list re-check (enforce) → argument redaction → per-tool rate limit
   // → per-tool result cache (wrapping execution + result scan + result redaction).
-  def callTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
+  def callTool(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
     val z = config.zeroTrust
     val granted = attrs.get(McpOAuthFilterUtils.McpGrantedScopesKey).getOrElse(Set.empty[String])
     if (!config.toolAllowedForScopes(name, granted)) Future.successful(Left(name))
@@ -1610,7 +1608,7 @@ object McpProxyLogic {
     }
   }
 
-  private def callToolInternal(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
+  private def callToolInternal(config: McpProxyEndpointConfig, name: String, arguments: JsObject, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[String, JsObject]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val functions = config.functionRefs.flatMap(r => ext.states.toolFunction(r))
     val functionsMap = functions.map(f => (f.name, f)).toMap
@@ -1630,7 +1628,7 @@ object McpProxyLogic {
   }
 
   // Full "resources" array: this server's managed (static) resources + every connector's resources.
-  def resourcesList(config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
+  def resourcesList(config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val mcpConnectors = config.mcpRefs.flatMap(r => ext.states.mcpConnector(r)).map(config.applyFiltersTo)
     val staticJson: Seq[JsValue] = config.resources.filter(r => config.matchesResource(r.name)).map(_.listJson)
@@ -1643,7 +1641,7 @@ object McpProxyLogic {
 
   // Reads a resource by uri. Managed (static) resources take precedence; otherwise it falls back to the
   // upstream connectors. Returns the `contents` array (empty when nothing matches).
-  def readResource(config: McpProxyEndpointConfig, uri: String, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsObject]] = {
+  def readResource(config: McpProxyEndpointConfig, uri: String, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsObject]] = {
     config.resources.find(_.uri == uri) match {
       case Some(res) => res.read(attrs, config.resourceFetchAllowedHosts, config.emitAuditEvents).map(Seq(_))
       case None =>
@@ -1661,7 +1659,7 @@ object McpProxyLogic {
   }
 
   // Full "resourceTemplates" array: every connector's resource templates (no managed templates), overlaid.
-  def templatesList(config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
+  def templatesList(config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val mcpConnectors = config.mcpRefs.flatMap(r => ext.states.mcpConnector(r)).map(config.applyFiltersTo)
     // recover per connector: a connector that doesn't support resources/templates/list (-32601) must not break the aggregate
@@ -1669,7 +1667,7 @@ object McpProxyLogic {
   }
 
   // Full "prompts" array: this server's managed (static) prompts + every connector's prompts.
-  def promptsList(config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
+  def promptsList(config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Seq[JsValue]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val mcpConnectors = config.mcpRefs.flatMap(r => ext.states.mcpConnector(r)).map(config.applyFiltersTo)
     val staticJson: Seq[JsValue] = config.prompts.filter(p => config.matchesPrompt(p.name)).map(_.listJson)
@@ -1682,9 +1680,9 @@ object McpProxyLogic {
 
   // Resolves a prompts/get. Managed (static) prompts take precedence; otherwise it falls back to the upstream
   // connectors. Returns the `{ description, messages }` payload.
-  def getPrompt(config: McpProxyEndpointConfig, name: String, arguments: Map[String, Object], attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[JsObject] = {
+  def getPrompt(config: McpProxyEndpointConfig, name: String, arguments: Map[String, Object], attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[JsObject] = {
     config.prompts.find(_.name == name) match {
-      case Some(prompt) => Future.successful(prompt.getJson(arguments.mapValues(_.toString).toMap, attrs))
+      case Some(prompt) => Future.successful(prompt.getJson(arguments.view.mapValues(_.toString).toMap, attrs))
       case None =>
         val ext = env.adminExtensions.extension[AiExtension].get
         val mcpConnectors = config.mcpRefs.flatMap(r => ext.states.mcpConnector(r)).map(config.applyFiltersTo)
@@ -1717,7 +1715,7 @@ case class SseSession(
   ref: AtomicReference[SourceQueueWithComplete[JsValue]] = new AtomicReference[SourceQueueWithComplete[JsValue]]()
 ) {
 
-  def init(): Source[JsValue, _] = {
+  def init(): Source[JsValue, ?] = {
     val stream = Source
       .queue[JsValue](1000, OverflowStrategy.dropHead)
       .takeWhile(_ => !finished.get())
@@ -1727,7 +1725,7 @@ case class SseSession(
     stream
   }
 
-  def send(id: Long, payload: JsValue)(implicit ec: ExecutionContext): Unit = {
+  def send(id: Long, payload: JsValue)(using ec: ExecutionContext): Unit = {
     if (!canceledRequests.contains(id)) {
       Option(ref.get()).foreach(_.offer(Json.obj(
         "jsonrpc" -> "2.0",
@@ -1779,7 +1777,7 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     ().vfuture
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     McpOAuthFilterUtils.access(ctx, internalName)
   }
 
@@ -1788,7 +1786,7 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     NgProxyEngineError.NgResultProxyEngineError(Results.Status(status)(Json.obj("error" -> msg))).leftf
   }
 
-  def jsonRpcResponse(id: Long, payload: JsValue)(implicit attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def jsonRpcResponse(id: Long, payload: JsValue)(using attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val envelope = Json.obj(
       "jsonrpc" -> "2.0",
       "id" -> id,
@@ -1798,12 +1796,12 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(envelope)), None).rightf
   }
 
-  def emptyResp(id: Long)(implicit attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def emptyResp(id: Long)(using attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     jsonRpcResponse(id, Json.obj())
   }
 
-  def initialize(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def initialize(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     config.computeCapabilities(attrs, includeLogging = false).flatMap { capabilities =>
       val response = Json.obj(
         "protocolVersion" -> "2025-06-18", //"2024-11-05",
@@ -1818,8 +1816,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getToolList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getToolList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.toolsList(config, attrs).flatMap { tools =>
       val response = Json.obj("tools" -> JsArray(tools))
       session.send(id, response)
@@ -1827,8 +1825,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def toolsCall(id: Long, session: SseSession, request: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def toolsCall(id: Long, session: SseSession, request: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     val params = request.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val name = params.select("name").asString
     val arguments = params.select("arguments").asOpt[JsObject].getOrElse(Json.obj())
@@ -1842,8 +1840,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getResourcesList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getResourcesList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.resourcesList(config, attrs).flatMap { resources =>
       val payload = Json.obj("resources" -> JsArray(resources))
       session.send(id, payload)
@@ -1851,8 +1849,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getPromptsList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getPromptsList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.promptsList(config, attrs).flatMap { prompts =>
       val payload = Json.obj("prompts" -> JsArray(prompts))
       session.send(id, payload)
@@ -1860,8 +1858,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getTemplatesList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getTemplatesList(id: Long, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.templatesList(config, attrs).flatMap { templates =>
       val payload = Json.obj("templates" -> JsArray(templates))
       session.send(id, payload)
@@ -1869,8 +1867,8 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def readResource(id: Long, json: JsValue, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def readResource(id: Long, json: JsValue, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     json.select("params").select("uri").asOpt[String] match {
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing uri parameter"))
       case Some(uri) =>
@@ -1882,13 +1880,13 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getPromptHandler(id: Long, json: JsValue, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getPromptHandler(id: Long, json: JsValue, session: SseSession, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     json.select("params").select("name").asOpt[String] match {
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing name parameter"))
       case Some(name) =>
         val arguments: Map[String, Object] = json.select("params").select("arguments").asOpt[JsObject].map { obj =>
-          obj.value.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
+          obj.value.view.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
         }.getOrElse(Map.empty)
         McpProxyLogic.getPrompt(config, name, arguments, attrs).flatMap { payload =>
           session.send(id, payload)
@@ -1897,15 +1895,15 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default).resolve()
     if (ctx.request.method.toLowerCase() == "get") {
       val sessionId = if (env.isDev) ctx.request.queryParam("sessionId").getOrElse(IdGenerator.token(16)) else IdGenerator.token(16)
       val session = SseSession(sessionId)
       // println(s"adding session: ${sessionId}")
       sessions.put(sessionId, session)
-      val sessionSource: Source[ByteString, _] = session.init().map(v => s"event: message\ndata: ${v.stringify}\n\n".byteString)
-      val source: Source[ByteString, _] = Source.single(ByteString(s"event: endpoint\ndata: ${ctx.rawRequest.path}?sessionId=${sessionId}\n\n"))
+      val sessionSource: Source[ByteString, ?] = session.init().map(v => s"event: message\ndata: ${v.stringify}\n\n".byteString)
+      val source: Source[ByteString, ?] = Source.single(ByteString(s"event: endpoint\ndata: ${ctx.rawRequest.path}?sessionId=${sessionId}\n\n"))
         .concat(sessionSource)
         .alsoTo(Sink.onComplete {
           case _ =>
@@ -1939,9 +1937,9 @@ class McpSseEndpoint extends NgBackendCall with NgAccessValidator {
               ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
                 // println(s"received client command raw ${sessionId} : ${bodyRaw.utf8String}")
                 Try(bodyRaw.utf8String.parseJson) match {
-                  case Failure(e) => error(400,"error while parsing json-rpc payload")
+                  case Failure(_) => error(400,"error while parsing json-rpc payload")
                   case Success(json) => {
-                    implicit val _attrs: TypedMap = ctx.attrs
+                    given _attrs: TypedMap = ctx.attrs
                     val id = json.select("id").asOpt[Long].getOrElse(0L)
                     val method = json.select("method").asOpt[String].getOrElse("--")
                     val start = System.currentTimeMillis()
@@ -2034,14 +2032,14 @@ class McpWebsocketEndpoint extends NgWebsocketBackendPlugin with NgAccessValidat
     ().vfuture
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     McpOAuthFilterUtils.access(ctx, internalName)
   }
 
-  override def callBackend(ctx: NgWebsocketPluginContext)(implicit env: Env, ec: ExecutionContext): Flow[Message, Message, _] = {
+  override def callBackend(ctx: NgWebsocketPluginContext)(using env: Env, ec: ExecutionContext): Flow[Message, Message, ?] = {
     val config = ctx.cachedConfig(internalName)(McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default).resolve()
     ActorFlow
-      .actorRef(out => McpActor.props(out, config, env, ctx.attrs))(env.otoroshiActorSystem, env.otoroshiMaterializer)
+      .actorRef(out => McpActor.props(out, config, env, ctx.attrs))(using env.otoroshiActorSystem, env.otoroshiMaterializer)
   }
 }
 
@@ -2051,7 +2049,7 @@ object McpActor {
 
 class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: TypedMap) extends Actor {
 
-  implicit val ec = env.otoroshiExecutionContext
+  given ec: ExecutionContext = env.otoroshiExecutionContext
 
   val ready = new AtomicBoolean(false)
   val canceledRequests = new TrieMap[Long, Unit]()
@@ -2088,8 +2086,8 @@ class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: T
   }
 
   def initialize(id: Long): Future[JsValue] = {
-    implicit val e: Env = env
-    implicit val ec: ExecutionContext = env.otoroshiExecutionContext
+    given e: Env = env
+    given ec: ExecutionContext = env.otoroshiExecutionContext
     config.computeCapabilities(attrs, includeLogging = false).map { capabilities =>
       val response = Json.obj(
         "protocolVersion" -> "2025-06-18",//"2024-11-05",
@@ -2104,16 +2102,16 @@ class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: T
   }
 
   def getToolList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap): Future[JsValue] = {
-    implicit val ec: ExecutionContext = env.otoroshiExecutionContext
-    implicit val ev: Env = env
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     McpProxyLogic.toolsList(config, attrs).map { tools =>
       jsonRpcResponse(id, Json.obj("tools" -> JsArray(tools)))
     }
   }
 
   def toolsCall(id: Long, request: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap): Future[JsValue] = {
-    implicit val ec: ExecutionContext = env.otoroshiExecutionContext
-    implicit val ev: Env = env
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given ev: Env = env
     val params = request.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val name = params.select("name").asString
     val arguments = params.select("arguments").asOpt[JsObject].getOrElse(Json.obj())
@@ -2124,30 +2122,30 @@ class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: T
   }
 
   def getResourcesList(id: Long, attrs: TypedMap): Future[JsValue] = {
-    McpProxyLogic.resourcesList(config, attrs)(env, ec).map { resources =>
+    McpProxyLogic.resourcesList(config, attrs)(using env, ec).map { resources =>
       jsonRpcResponse(id, Json.obj("resources" -> JsArray(resources)))
-    }(ec)
+    }(using ec)
   }
 
   def getPromptsList(id: Long, attrs: TypedMap): Future[JsValue] = {
-    McpProxyLogic.promptsList(config, attrs)(env, ec).map { prompts =>
+    McpProxyLogic.promptsList(config, attrs)(using env, ec).map { prompts =>
       jsonRpcResponse(id, Json.obj("prompts" -> JsArray(prompts)))
-    }(ec)
+    }(using ec)
   }
 
   def getTemplatesList(id: Long, attrs: TypedMap): Future[JsValue] = {
-    McpProxyLogic.templatesList(config, attrs)(env, ec).map { templates =>
+    McpProxyLogic.templatesList(config, attrs)(using env, ec).map { templates =>
       jsonRpcResponse(id, Json.obj("templates" -> JsArray(templates)))
-    }(ec)
+    }(using ec)
   }
 
   def readResource(id: Long, json: JsValue, attrs: TypedMap): Future[JsValue] = {
     json.select("params").select("uri").asOpt[String] match {
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing uri parameter")).vfuture
       case Some(uri) =>
-        McpProxyLogic.readResource(config, uri, attrs)(env, ec).map { contents =>
+        McpProxyLogic.readResource(config, uri, attrs)(using env, ec).map { contents =>
           jsonRpcResponse(id, Json.obj("contents" -> JsArray(contents)))
-        }(ec)
+        }(using ec)
     }
   }
 
@@ -2156,18 +2154,18 @@ class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: T
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing name parameter")).vfuture
       case Some(name) =>
         val arguments: Map[String, Object] = json.select("params").select("arguments").asOpt[JsObject].map { obj =>
-          obj.value.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
+          obj.value.view.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
         }.getOrElse(Map.empty)
-        McpProxyLogic.getPrompt(config, name, arguments, attrs)(env, ec).map { payload =>
+        McpProxyLogic.getPrompt(config, name, arguments, attrs)(using env, ec).map { payload =>
           jsonRpcResponse(id, payload)
-        }(ec)
+        }(using ec)
     }
   }
 
   def handle(data: String): Unit = {
     // println(s"handle ws raw message: ${data}")
     Try(data.parseJson) match {
-      case Failure(e) => send(jsonRpcError(0, 400, "error while parsing json-rpc payload", Json.obj()))
+      case Failure(_) => send(jsonRpcError(0, 400, "error while parsing json-rpc payload", Json.obj()))
       case Success(json) => {
         val id = json.select("id").asOpt[Long].getOrElse(0L)
         val method = json.select("method").asOpt[String].getOrElse("--")
@@ -2208,17 +2206,17 @@ class McpActor(out: ActorRef, config: McpProxyEndpointConfig, env: Env, attrs: T
         }
         resp.onComplete { r =>
           val dur = System.currentTimeMillis() - start
-          McpAuditHelper.markMetrics(method, dur, isError = r.isFailure)(env)
+          McpAuditHelper.markMetrics(method, dur, isError = r.isFailure)(using env)
           if (config.emitAuditEvents) {
             r match {
               case Success(response) =>
-                McpAuditHelper.emit(method, id, json, dur, "websocket", None, attrs, response)(env)
+                McpAuditHelper.emit(method, id, json, dur, "websocket", None, attrs, response)(using env)
               case Failure(ex) =>
-                McpAuditHelper.emit(method, id, json, dur, "websocket", Some(ex.getMessage), attrs)(env)
+                McpAuditHelper.emit(method, id, json, dur, "websocket", Some(ex.getMessage), attrs)(using env)
             }
           }
         }
-        resp.map(r => send(r))(env.otoroshiExecutionContext)
+        resp.map(r => send(r))(using env.otoroshiExecutionContext)
       }
     }
   }
@@ -2263,7 +2261,7 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     NgProxyEngineError.NgResultProxyEngineError(Results.Status(status)(Json.obj("error" -> msg))).leftf
   }
 
-  def jsonRpcResponse(id: Long, payload: JsValue)(implicit attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def jsonRpcResponse(id: Long, payload: JsValue)(using attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val envelope = Json.obj(
       "jsonrpc" -> "2.0",
       "id" -> id,
@@ -2273,12 +2271,12 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(envelope)), None).rightf
   }
 
-  def emptyResp(id: Long)(implicit attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def emptyResp(id: Long)(using attrs: TypedMap): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     jsonRpcResponse(id, Json.obj())
   }
 
-  def initialize(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def initialize(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     config.computeCapabilities(attrs, includeLogging = false).flatMap { capabilities =>
       val response = Json.obj(
         "protocolVersion" -> "2025-06-18", //"2024-11-05",
@@ -2292,15 +2290,15 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getToolList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getToolList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.toolsList(config, attrs).flatMap { tools =>
       jsonRpcResponse(id, Json.obj("tools" -> JsArray(tools)))
     }
   }
 
-  def toolsCall(id: Long, request: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def toolsCall(id: Long, request: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     val params = request.select("params").asOpt[JsObject].getOrElse(Json.obj())
     val name = params.select("name").asString
     val arguments = params.select("arguments").asOpt[JsObject].getOrElse(Json.obj())
@@ -2310,29 +2308,29 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getResourcesList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getResourcesList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.resourcesList(config, attrs).flatMap { resources =>
       jsonRpcResponse(id, Json.obj("resources" -> JsArray(resources)))
     }
   }
 
-  def getPromptsList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getPromptsList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.promptsList(config, attrs).flatMap { prompts =>
       jsonRpcResponse(id, Json.obj("prompts" -> JsArray(prompts)))
     }
   }
 
-  def getTemplatesList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getTemplatesList(id: Long, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     McpProxyLogic.templatesList(config, attrs).flatMap { templates =>
       jsonRpcResponse(id, Json.obj("templates" -> JsArray(templates)))
     }
   }
 
-  def readResource(id: Long, json: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def readResource(id: Long, json: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     json.select("params").select("uri").asOpt[String] match {
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing uri parameter"))
       case Some(uri) =>
@@ -2342,13 +2340,13 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  def getPromptHandler(id: Long, json: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(implicit env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
-    implicit val _attrs: TypedMap = attrs
+  def getPromptHandler(id: Long, json: JsValue, config: McpProxyEndpointConfig, attrs: TypedMap)(using env: Env, ec: ExecutionContext): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+    given _attrs: TypedMap = attrs
     json.select("params").select("name").asOpt[String] match {
       case None => jsonRpcResponse(id, Json.obj("error" -> "missing name parameter"))
       case Some(name) =>
         val arguments: Map[String, Object] = json.select("params").select("arguments").asOpt[JsObject].map { obj =>
-          obj.value.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
+          obj.value.view.mapValues(v => v.asOpt[String].getOrElse(v.stringify).asInstanceOf[Object]).toMap
         }.getOrElse(Map.empty)
         McpProxyLogic.getPrompt(config, name, arguments, attrs).flatMap { payload =>
           jsonRpcResponse(id, payload)
@@ -2356,18 +2354,18 @@ class McpRespEndpoint extends NgBackendCall with NgAccessValidator {
     }
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     McpOAuthFilterUtils.access(ctx, internalName)
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(McpProxyEndpointConfig.format).getOrElse(McpProxyEndpointConfig.default).resolve()
     if (ctx.request.hasBody && ctx.request.method.toLowerCase() == "post") {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         Try(bodyRaw.utf8String.parseJson) match {
-          case Failure(e) => error(400,"error while parsing json-rpc payload")
+          case Failure(_) => error(400,"error while parsing json-rpc payload")
           case Success(json) => {
-            implicit val _attrs: TypedMap = ctx.attrs
+            given _attrs: TypedMap = ctx.attrs
             // println(s"mcp in >>> ${json.prettify}")
             val id = json.select("id").asOpt[Long].getOrElse(0L)
             val method = json.select("method").asOpt[String].getOrElse("--")
@@ -2426,7 +2424,7 @@ case class McpProtectedResourceMetadataConfig(
   def json: JsValue = McpProtectedResourceMetadataConfig.format.writes(this)
   // effective auth module: the explicit authModuleRef, else the one configured on the referenced MCP
   // virtual server (so the preset can drive both plugins from just a server ref).
-  def effectiveAuthModuleRef(implicit env: Env): Option[String] = authModuleRef.orElse {
+  def effectiveAuthModuleRef(using env: Env): Option[String] = authModuleRef.orElse {
     serverRef
       .flatMap(r => env.adminExtensions.extension[AiExtension].flatMap(_.states.mcpVirtualServer(r)))
       .flatMap(_.config.authModuleRef)
@@ -2533,7 +2531,7 @@ class McpProtectedResourceMetadata extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(McpProtectedResourceMetadataConfig.format).getOrElse(McpProtectedResourceMetadataConfig.default)
     config.effectiveAuthModuleRef match {
       case None =>
@@ -2807,7 +2805,7 @@ class McpRegistryWellKnown extends NgBackendCall {
   override def configFlow: Seq[String] = McpRegistryWellKnownConfig.configFlow
   override def configSchema: Option[JsObject] = McpRegistryWellKnownConfig.configSchema
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(McpRegistryWellKnownConfig.format).getOrElse(McpRegistryWellKnownConfig.default)
     val registryUrl = config.registryUrl.filter(_.trim.nonEmpty).getOrElse(s"${ctx.rawRequest.theProtocol}://${ctx.rawRequest.theHost}/v0")
     val doc = Json.obj(
@@ -2895,7 +2893,7 @@ class McpRegistryApi extends NgBackendCall {
   override def configFlow: Seq[String] = McpRegistryApiConfig.configFlow
   override def configSchema: Option[JsObject] = McpRegistryApiConfig.configSchema
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(McpRegistryApiConfig.format).getOrElse(McpRegistryApiConfig.default)
     val allServers = env.adminExtensions.extension[AiExtension].get.states.allMcpVirtualServers()
     // restrict to the subset this registry exposes (all / by ref / by tag / route's tenant)
@@ -3050,7 +3048,7 @@ object McpExpositionScanner {
 
   // https://<host[/frontend-path]><exposition-path>, normalizing slashes. Scheme is assumed https (Otoroshi
   // default; it isn't stored on the route — which is exactly why the admin confirms the suggestion).
-  def deriveUrl(domainAndPathRaw: String, includePath: Option[String], forceHttps: Boolean)(implicit env: Env): String = {
+  def deriveUrl(domainAndPathRaw: String, includePath: Option[String], forceHttps: Boolean)(using env: Env): String = {
     val base = domainAndPathRaw.trim.stripSuffix("/")
     val p = includePath.map(_.trim).filter(_.nonEmpty).map(s => if (s.startsWith("/")) s else "/" + s).getOrElse("")
     val url = if (forceHttps) {
@@ -3091,7 +3089,7 @@ object McpExpositionScanner {
     )
   }
 
-  def scan(vsId: String)(implicit env: Env): Seq[Candidate] = {
+  def scan(vsId: String)(using env: Env): Seq[Candidate] = {
     env.proxyState.allRoutes().filter(_.enabled).flatMap { route =>
       val slots = route.plugins.slots.filter(_.enabled)
       val mcpSlots = slots.filter(s => slotReferences(s.plugin, s.config.raw, vsId))

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/modelcapabilities.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/modelcapabilities.scala
@@ -1,13 +1,13 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvidersCatalog
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +16,7 @@ object LlmModelCapabilities {
 
   // Returns every model type (modality) Otoroshi LLM supports — text, audio, image, ocr,
   // embedding, moderation, video — each with the provider ids exposing it.
-  def handleRequest(ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     Right(BackendCallResponse(NgPluginHttpResponse.fromResult(
       Results.Ok(Json.obj(
         "object" -> "list",
@@ -47,7 +47,7 @@ class LlmModelCapabilities extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     LlmModelCapabilities.handleRequest(ctx)
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/models.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/models.scala
@@ -1,18 +1,18 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
-import com.cloud.apim.otoroshi.extensions.aigateway.plugins._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import com.cloud.apim.otoroshi.extensions.aigateway.plugins.*
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsArray, JsObject, Json}
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util._
+import scala.util.*
 
 class OpenAiCompatModels extends NgBackendCall {
 
@@ -35,7 +35,7 @@ class OpenAiCompatModels extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     val ext = env.adminExtensions.extension[AiExtension].get
     Source(config.refs.toList)
@@ -81,7 +81,7 @@ class OpenAiCompatModels extends NgBackendCall {
 }
 
 object OpenAiCompatProvidersWithModels {
-  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val now: Long = System.currentTimeMillis() / 1000
     Source(config.refs.toList)
@@ -151,7 +151,7 @@ class OpenAiCompatProvidersWithModels extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     OpenAiCompatProvidersWithModels.handleRequest(config, ctx)
   }
@@ -178,7 +178,7 @@ class LlmProviderModels extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     val ext = env.adminExtensions.extension[AiExtension].get
     Source(config.refs.toList)
@@ -235,7 +235,7 @@ class LlmProvidersWithModels extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     val ext = env.adminExtensions.extension[AiExtension].get
     Source(config.refs.toList)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/moderation.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/moderation.scala
@@ -1,15 +1,15 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.ModerationModelClientInputOptions
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.ModerationModel
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -48,7 +48,7 @@ object OpenAICompatModerationConfig {
       case Success(value) => JsSuccess(value)
     }
   }
-  def getProvidersMap(config: OpenAICompatModerationConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, ModerationModel], Map[String, ModerationModel]) = {
+  def getProvidersMap(config: OpenAICompatModerationConfig)(using ec: ExecutionContext, env: Env): (Map[String, ModerationModel], Map[String, ModerationModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.moderationModel(ref))
     val providersByName = providers.map { provider =>
@@ -59,7 +59,7 @@ object OpenAICompatModerationConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatModerationConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: OpenAICompatModerationConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -97,7 +97,7 @@ object OpenAICompatModerationConfig {
 }
 
 object OpenAICompatModeration {
-  def handleRequest(config: OpenAICompatModerationConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatModerationConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val _jsonBody = bodyRaw.utf8String.parseJson
@@ -151,7 +151,7 @@ class OpenAICompatModeration extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatModerationConfig.format).getOrElse(OpenAICompatModerationConfig.default)
     OpenAICompatModeration.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/ocr.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/ocr.scala
@@ -1,16 +1,16 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.{AiMetrics, OcrModelClientInputOptions}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.OcrModel
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.http._
-import play.api.libs.json._
+import play.api.http.*
+import play.api.libs.json.*
 import play.api.mvc.{RequestHeader, Result, Results}
 import play.core.parsers.Multipart
 
@@ -55,7 +55,7 @@ object OpenAICompatOcrConfig {
     }
   }
 
-  def resolveProvider(jsonBody: JsObject, config: OpenAICompatOcrConfig)(implicit ec: ExecutionContext, env: Env): Option[OcrModel] = {
+  def resolveProvider(jsonBody: JsObject, config: OpenAICompatOcrConfig)(using ec: ExecutionContext, env: Env): Option[OcrModel] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap(r => ext.states.ocrModel(r))
       .orElse(config.refs.headOption.flatMap(r => ext.states.ocrModel(r)))
@@ -64,7 +64,7 @@ object OpenAICompatOcrConfig {
 
 object OpenAICompatOcr {
 
-  def handleRequest(config: OpenAICompatOcrConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: OpenAICompatOcrConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val isMultipart = ctx.rawRequest.contentType.exists(_.toLowerCase.contains("multipart/form-data"))
     if (isMultipart) {
       Multipart.multipartParser(
@@ -100,7 +100,7 @@ object OpenAICompatOcr {
     }
   }
 
-  private def executeOcr(config: OpenAICompatOcrConfig, jsonBody: JsObject, fileBytes: Option[ByteString], fileContentType: Option[String], fileName: Option[String], ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  private def executeOcr(config: OpenAICompatOcrConfig, jsonBody: JsObject, fileBytes: Option[ByteString], fileContentType: Option[String], fileName: Option[String], ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     OpenAICompatOcrConfig.resolveProvider(jsonBody, config) match {
       case None => NgProxyEngineError.NgResultProxyEngineError(Results.InternalServerError(Json.obj("error" -> "internal_error", "error_details" -> "provider not found"))).leftf
       case Some(model) => model.getOcrModelClient() match {
@@ -142,7 +142,7 @@ class OpenAICompatOcr extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAICompatOcrConfig.format).getOrElse(OpenAICompatOcrConfig.default)
     OpenAICompatOcr.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openaiapi.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openaiapi.scala
@@ -1,13 +1,13 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.AiPluginRefsConfig
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -221,7 +221,7 @@ class OpenAiCompatApi extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(OpenAiCompatApiConfig.format).getOrElse(OpenAiCompatApiConfig.default)
     val path = ctx.request.path
     val method = ctx.request.method.toUpperCase()

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openaiproxy.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openaiproxy.scala
@@ -1,15 +1,15 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.{AiPluginRefsConfig, AiPluginsKeys}
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt, InputChatMessage, OpenAiResponsesBodyConverter, ResponsesStreamAccumulator}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import otoroshi.security.IdGenerator
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsValue, Json}
@@ -28,7 +28,7 @@ object OpenAiCompatProxy {
     }
   }
 
-  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsonBody, config)
     val provider: Option[AiProvider] = jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap { r =>
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(r))
@@ -75,7 +75,7 @@ object OpenAiCompatProxy {
             client.call(ChatPrompt(messages), ctx.attrs, jsonBody).map {
               case Left(err) => Left(NgProxyEngineError.NgResultProxyEngineError(Results.BadRequest(err)))
               case Right(response) => Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.openaiJson(client.computeModel(jsonBody).getOrElse("none"), env))
-                .withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+                .withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -85,7 +85,7 @@ object OpenAiCompatProxy {
     }
   }
 
-  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -126,7 +126,7 @@ class OpenAiCompatProxy extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     OpenAiCompatProxy.handleRequest(config, ctx)
   }
@@ -155,7 +155,7 @@ class OpenAiCompletionProxy extends NgBackendCall {
     ().vfuture
   }
 
-  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsonBody, config)
     val provider: Option[AiProvider] = jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap { r =>
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(r))
@@ -169,7 +169,6 @@ class OpenAiCompletionProxy extends NgBackendCall {
       case Some(client) => {
         val stream = ctx.request.queryParam("stream").contains("true") || ctx.request.header("x-stream").contains("true") || jsonBody.select("stream").asOpt[Boolean].contains(true)
         val echo = jsonBody.select("echo").asOptBoolean.getOrElse(false)
-        val suffix = jsonBody.select("suffix").asOptString
 
         val requestMessages: Seq[JsObject] = ctx.attrs.get(AiPluginsKeys.PromptTemplateKey) match {
           case None => Seq(Json.obj("role" -> "user", "content" -> jsonBody.select("prompt").asString))
@@ -205,7 +204,7 @@ class OpenAiCompletionProxy extends NgBackendCall {
             client.tryCompletion(ChatPrompt(messages), ctx.attrs, jsonBody).map {
               case Left(err) => Left(NgProxyEngineError.NgResultProxyEngineError(Results.BadRequest(err)))
               case Right(response) => Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.openaiCompletionJson(client.computeModel(jsonBody).getOrElse("none"), echo, messages.head.content, env))
-                .withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+                .withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -225,7 +224,7 @@ class OpenAiCompletionProxy extends NgBackendCall {
     }
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -245,7 +244,7 @@ class OpenAiCompletionProxy extends NgBackendCall {
 
 object OpenAiResponsesProxy {
 
-  def call(_jsb: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsb: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val _jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsb, config)
     val provider: Option[AiProvider] = _jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap { r =>
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(r))
@@ -330,7 +329,7 @@ object OpenAiResponsesProxy {
 
                 // materialized by `concatLazy` only once the content events are done, which is what
                 // makes the accumulated text, tool calls and usage available here
-                val footerEvents = Source.lazily(() => {
+                val footerEvents = Source.lazySource(() => {
                   val text = acc.wholeText
                   val completedContentPart = Json.obj(
                     "type" -> "output_text",
@@ -345,7 +344,7 @@ object OpenAiResponsesProxy {
                     "content" -> JsArray(Seq(completedContentPart))
                   )
                   // tool calls streamed as deltas are reported as `function_call` output items
-                  val functionCallItems = acc.functionCallItems(idx => s"fc_${IdGenerator.token(24)}")
+                  val functionCallItems = acc.functionCallItems(_ => s"fc_${IdGenerator.token(24)}")
                   val completedResponse = Json.obj(
                     "id" -> responseId,
                     "object" -> "response",
@@ -397,7 +396,7 @@ object OpenAiResponsesProxy {
             client.tryResponse(ChatPrompt(messages), ctx.attrs, jsonBody).map {
               case Left(err) => Left(NgProxyEngineError.NgResultProxyEngineError(Results.BadRequest(err)))
               case Right(response) => Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.openaiResponseJson(client.computeModel(jsonBody).getOrElse("none"), env))
-                .withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+                .withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -407,7 +406,7 @@ object OpenAiResponsesProxy {
     }
   }
 
-  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -448,7 +447,7 @@ class OpenAiResponsesProxy extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefsConfig.format).getOrElse(AiPluginRefsConfig.default)
     OpenAiResponsesProxy.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openresponseproxy.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/openresponseproxy.scala
@@ -1,18 +1,18 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.{AiPluginRefsConfig, AiPluginsKeys}
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessageContent, ChatPrompt, ChatResponse, InputChatMessage, OpenAiResponsesBodyConverter, ResponsesStreamAccumulator}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
 import otoroshi.security.IdGenerator
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object OpenResponseCompatProxy {
 
-  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -66,9 +66,7 @@ class OpenResponseCompatProxy extends NgBackendCall {
     if (response.isNativeResponsePayload) {
       return response.openaiResponseJson(model, env)
     }
-    val respId = s"resp_${IdGenerator.token(32)}"
     val msgId = s"msg_${IdGenerator.token(32)}"
-    val createdAt = System.currentTimeMillis() / 1000
 
     val textOutputs: Seq[JsObject] = response.generations.filter(!_.message.has_tool_calls).map { gen =>
       Json.obj(
@@ -182,6 +180,8 @@ class OpenResponseCompatProxy extends NgBackendCall {
       "summary" -> "auto"
     ))
 
+    val respId = s"resp_${IdGenerator.token(32)}"
+    val createdAt = System.currentTimeMillis() / 1000
     Json.obj(
       "id" -> respId,
       "object" -> "response",
@@ -221,7 +221,7 @@ class OpenResponseCompatProxy extends NgBackendCall {
     s"event: $eventType\ndata: ${data.stringify}\n\n".byteString
   }
 
-  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsonBody, config)
     val provider: Option[AiProvider] = jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap { r =>
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(r))
@@ -246,10 +246,8 @@ class OpenResponseCompatProxy extends NgBackendCall {
             InputChatMessage.fromJson(obj)
           }
           if (stream) {
-            val respId = s"resp_${IdGenerator.token(32)}"
             val msgId = s"msg_${IdGenerator.token(32)}"
             val model = client.computeModel(openAiBody).getOrElse("none")
-            val createdAt = System.currentTimeMillis() / 1000
             val tools = OpenAiResponsesBodyConverter.normalizeResponsesTools(jsonBody.select("tools").asOpt[Seq[JsObject]].getOrElse(Seq.empty))
 
             def eventWithResponse(typ: String, seqNum: Int): JsObject = {
@@ -311,7 +309,7 @@ class OpenResponseCompatProxy extends NgBackendCall {
 
                 // materialized by `concatLazy` only once the delta events are done, which is what
                 // makes the accumulated text, tool calls and usage available here
-                val footerEvents = Source.lazily { () =>
+                val footerEvents = Source.lazySource { () =>
                   val text = acc.wholeText
                   val contentPart = Json.obj("type" -> "output_text", "text" -> text, "annotations" -> Json.arr(), "logprobs" -> Json.arr())
                   val messageItem = msgItem.deepMerge(Json.obj("status" -> "completed", "content" -> Json.arr(contentPart)))
@@ -373,7 +371,7 @@ class OpenResponseCompatProxy extends NgBackendCall {
                 val model = client.computeModel(openAiBody).getOrElse("none")
                 val tools = OpenAiResponsesBodyConverter.normalizeResponsesTools(jsonBody.select("tools").asOpt[Seq[JsObject]].getOrElse(Seq.empty))
                 Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(buildResponseJson(response, model, jsonBody.asObject, tools, env))
-                  .withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+                  .withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -399,7 +397,7 @@ class OpenResponseCompatProxy extends NgBackendCall {
     }
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/pow.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/pow.scala
@@ -1,22 +1,22 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import otoroshi.cluster.Cluster
 import otoroshi.env.Env
 import otoroshi.gateway.Retry
 import otoroshi.models.{ApiKey, IpFiltering}
-import otoroshi.next.extensions._
-import otoroshi.next.plugins.api._
-import otoroshi.utils.RegexPool
-import otoroshi.utils.http.Implicits._
-import otoroshi.utils.http.RequestImplicits._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.extensions.*
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.http.Implicits.*
+import otoroshi.utils.http.RequestImplicits.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.ws.WSAuthScheme
-import play.api.mvc._
+import play.api.libs.ws.WSBodyWritables.given
+import play.api.mvc.*
 
 import java.security.MessageDigest
 import java.time.Instant
@@ -25,9 +25,10 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 import scala.util.{Failure, Random, Success, Try}
+import org.apache.pekko.actor.Scheduler
 
 case class PowConfig(
   difficulty: Int = 8,
@@ -90,7 +91,7 @@ case class PowConfig(
     }
   }
 
-  def isHeaderBypassed(req: RequestHeader)(implicit env: Env): Boolean = {
+  def isHeaderBypassed(req: RequestHeader)(using env: Env): Boolean = {
     if (allowedHeaders.isEmpty && blockedHeaders.isEmpty) {
       false
     } else if (allowedHeaders.nonEmpty && allowedHeaders.exists {
@@ -106,7 +107,7 @@ case class PowConfig(
     }
   }
 
-  def isBypassed(req: RequestHeader)(implicit env: Env): Boolean = {
+  def isBypassed(req: RequestHeader)(using env: Env): Boolean = {
     isIpBypassed(req.theIpAddress) && isUserAgentBypassed(req.theUserAgent) && isHeaderBypassed(req)
   }
 }
@@ -272,7 +273,7 @@ object Pow {
       val n = Integer.parseInt(c.toString, 16)
       val bin = f"$n%4s".replace(' ', '0')
       bin
-    }.takeWhile(_ == '0').length
+    }.takeWhile(_ == '0').size
   }
 
   private def hmacSha256(data: String, secret: String): String = {
@@ -283,7 +284,7 @@ object Pow {
 
   case class PowToken(exp: Long, ip: Option[String], ua: Option[String])
   object PowToken {
-    implicit val f: OFormat[PowToken] = Json.format[PowToken]
+    given f: OFormat[PowToken] = Json.format[PowToken]
   }
 
   def signToken(tok: PowToken, secret: String): String = {
@@ -312,7 +313,7 @@ object ProofOfWorkPlugin {
 
   private val counter = new AtomicInteger(0)
 
-  private def prefixKey(implicit env: Env) = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:pow_challenge_tokens:"
+  private def prefixKey(using env: Env) = s"${env.storageRoot}:extensions:${AiExtension.id.cleanup}:pow_challenge_tokens:"
 
   private def otoroshiUrl(env: Env): String = {
     val config = env.clusterConfig
@@ -321,10 +322,9 @@ object ProofOfWorkPlugin {
   }
 
   // POST /api/extensions/cloud-apim/extensions/ai-extension/pow-challenges/:key
-  def handlePowChallengeCreate(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]])(implicit env: Env): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handlePowChallengeCreate(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]])(using env: Env): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
+    given mat: Materializer = env.otoroshiMaterializer
     ctx.named("key") match {
       case None => Results.BadRequest(Json.obj("error" -> "no key found")).vfuture
       case Some(challengeId) => {
@@ -334,7 +334,7 @@ object ProofOfWorkPlugin {
             val bodyJson = body.utf8String.parseJson
             val challenge = bodyJson.select("challenge").asObject
             val conf = PowConfig.format.reads(bodyJson.select("conf").asObject).get
-            setChallenge(challengeId, challenge, conf)(env, ec).map { _ =>
+            setChallenge(challengeId, challenge, conf)(using env, ec).map { _ =>
               Results.NoContent
             }
           }
@@ -344,14 +344,12 @@ object ProofOfWorkPlugin {
   }
 
   // GET /api/extensions/cloud-apim/extensions/ai-extension/pow-challenges/:key
-  def handlePowChallengeRead(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]])(implicit env: Env): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handlePowChallengeRead(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]])(using env: Env): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
     ctx.named("key") match {
       case None => Results.BadRequest(Json.obj("error" -> "no key found")).vfuture
       case Some(challengeId) => {
-        getChallenge(challengeId, PowConfig.default)(env, ec).map {
+        getChallenge(challengeId, PowConfig.default)(using env, ec).map {
           case Some(challenge) => Results.Ok(challenge)
           case None => Results.NotFound(Json.obj("error" -> "challenge not found"))
         }
@@ -360,30 +358,28 @@ object ProofOfWorkPlugin {
   }
 
   // DELETE /api/extensions/cloud-apim/extensions/ai-extension/pow-challenges/:key
-  def handlePowChallengeDelete(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, _]])(implicit env: Env): Future[Result] = {
-    implicit val ec = env.otoroshiExecutionContext
-    implicit val mat = env.otoroshiMaterializer
-    implicit val ev = env
+  def handlePowChallengeDelete(ctx: AdminExtensionRouterContext[AdminExtensionAdminApiRoute], req: RequestHeader, apikey: ApiKey, body: Option[Source[ByteString, ?]])(using env: Env): Future[Result] = {
+    given ec: ExecutionContext = env.otoroshiExecutionContext
     ctx.named("key") match {
       case None => Results.BadRequest(Json.obj("error" -> "no key found")).vfuture
       case Some(challengeId) => {
-        deleteChallenge(challengeId)(env, ec).map { _ =>
+        deleteChallenge(challengeId)(using env, ec).map { _ =>
           Results.NoContent
         }
       }
     }
   }
 
-  def callLeaderChallengeRead(challengeId: String)(implicit env: Env, ec: ExecutionContext): Future[Option[JsObject]] = {
+  def callLeaderChallengeRead(challengeId: String)(using env: Env, ec: ExecutionContext): Future[Option[JsObject]] = {
     val config = env.clusterConfig
-    implicit val sc = env.otoroshiScheduler
+    given sc: Scheduler = env.otoroshiScheduler
     Retry
       .retry(
         times = config.worker.retries,
         delay = config.retryDelay,
         factor = config.retryFactor,
         ctx = "leader-read-challenge-token"
-      ) { tryCount =>
+      ) { _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(s"Reading challenge $challengeId from Otoroshi leader cluster")
         env.MtlsWs
@@ -406,7 +402,7 @@ object ProofOfWorkPlugin {
             }
           }
       }
-      .recover { case e =>
+      .recover { case _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(
             s"[${env.clusterConfig.mode.name}] Error while reading challenge $challengeId from Otoroshi leader cluster"
@@ -415,16 +411,16 @@ object ProofOfWorkPlugin {
       }
   }
 
-  def callLeaderChallengeDelete(challengeId: String)(implicit env: Env, ec: ExecutionContext): Future[Unit] = {
+  def callLeaderChallengeDelete(challengeId: String)(using env: Env, ec: ExecutionContext): Future[Unit] = {
     val config = env.clusterConfig
-    implicit val sc = env.otoroshiScheduler
+    given sc: Scheduler = env.otoroshiScheduler
     Retry
       .retry(
         times = config.worker.retries,
         delay = config.retryDelay,
         factor = config.retryFactor,
         ctx = "leader-delete-challenge-token"
-      ) { tryCount =>
+      ) { _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(s"Deleting challenge $challengeId from Otoroshi leader cluster")
         env.MtlsWs
@@ -439,29 +435,28 @@ object ProofOfWorkPlugin {
           .withRequestTimeout(Duration(config.worker.timeout, TimeUnit.MILLISECONDS))
           .withMaybeProxyServer(config.proxy)
           .delete()
-          .map { resp =>
+          .map { _ =>
             ()
           }
       }
-      .recover { case e =>
+      .recover { case _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(
             s"[${env.clusterConfig.mode.name}] Error while deleting challenge $challengeId from Otoroshi leader cluster"
           )
-        None
       }
   }
 
-  def callLeaderChallengeWrite(challengeId: String, challenge: JsObject, conf: PowConfig)(implicit env: Env, ec: ExecutionContext): Future[Unit] = {
+  def callLeaderChallengeWrite(challengeId: String, challenge: JsObject, conf: PowConfig)(using env: Env, ec: ExecutionContext): Future[Unit] = {
     val config = env.clusterConfig
-    implicit val sc = env.otoroshiScheduler
+    given sc: Scheduler = env.otoroshiScheduler
     Retry
       .retry(
         times = config.worker.retries,
         delay = config.retryDelay,
         factor = config.retryFactor,
         ctx = "leader-push-challeng-token"
-      ) { tryCount =>
+      ) { _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(s"Pushing challenge $challengeId to Otoroshi leader cluster")
         env.MtlsWs
@@ -476,20 +471,19 @@ object ProofOfWorkPlugin {
           .withRequestTimeout(Duration(config.worker.timeout, TimeUnit.MILLISECONDS))
           .withMaybeProxyServer(config.proxy)
           .post(Json.obj("challenge" -> challenge, "conf" -> conf.json))
-          .map { resp =>
+          .map { _ =>
             ()
           }
       }
-      .recover { case e =>
+      .recover { case _ =>
         if (Cluster.logger.isDebugEnabled)
           Cluster.logger.debug(
             s"[${env.clusterConfig.mode.name}] Error while pushing challenge $challengeId to Otoroshi leader cluster"
           )
-        None
       }
   }
 
-  def getChallenge(challengeId: String, conf: PowConfig)(implicit env: Env, ec: ExecutionContext): Future[Option[JsObject]] = {
+  def getChallenge(challengeId: String, conf: PowConfig)(using env: Env, ec: ExecutionContext): Future[Option[JsObject]] = {
     val key = s"$prefixKey$challengeId"
     env.datastores.rawDataStore.get(key) flatMap {
       case None if env.clusterConfig.mode.isWorker => ProofOfWorkPlugin.callLeaderChallengeRead(challengeId).map { r =>
@@ -503,7 +497,7 @@ object ProofOfWorkPlugin {
     }
   }
 
-  def setChallenge(challengeId: String, challenge: JsObject, conf: PowConfig)(implicit env: Env, ec: ExecutionContext): Future[Unit] = {
+  def setChallenge(challengeId: String, challenge: JsObject, conf: PowConfig)(using env: Env, ec: ExecutionContext): Future[Unit] = {
     val key = s"$prefixKey$challengeId"
     env.datastores.rawDataStore.set(key, challenge.stringify.byteString, Some(conf.challengeTtlSeconds.seconds.toMillis)).flatMap {
       case _ if env.clusterConfig.mode.isWorker => ProofOfWorkPlugin.callLeaderChallengeWrite(challengeId, challenge, conf)
@@ -511,7 +505,7 @@ object ProofOfWorkPlugin {
     }
   }
 
-  def deleteChallenge(challengeId: String)(implicit env: Env, ec: ExecutionContext): Future[Unit] = {
+  def deleteChallenge(challengeId: String)(using env: Env, ec: ExecutionContext): Future[Unit] = {
     val key = s"$prefixKey$challengeId"
     env.datastores.rawDataStore.del(Seq(key)).flatMap {
       case _ if env.clusterConfig.mode.isWorker => ProofOfWorkPlugin.callLeaderChallengeDelete(challengeId)
@@ -538,7 +532,7 @@ class ProofOfWorkPlugin extends NgRequestTransformer {
   override def transformsResponse: Boolean = false
   override def transformsRequest: Boolean = true
 
-  override def transformRequest(ctx: NgTransformerRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
+  override def transformRequest(ctx: NgTransformerRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
     val config = ctx.cachedConfig(internalName)(PowConfig.format).getOrElse(PowConfig.default)
     if (config.isBypassed(ctx.request)) {
       ctx.otoroshiRequest.rightf
@@ -563,7 +557,7 @@ class ProofOfWorkPlugin extends NgRequestTransformer {
     }
   }
 
-  private def powPage(state: String, challenge: JsObject)(implicit env: Env): Result = {
+  private def powPage(state: String, challenge: JsObject)(using env: Env): Result = {
     val html =
       s"""<!doctype html>
 <meta charset="utf-8">
@@ -648,7 +642,7 @@ class ProofOfWorkPlugin extends NgRequestTransformer {
     Results.Ok(html).as("text/html")
   }
 
-  private def powChallenge(state: String, conf: PowConfig)(implicit env: Env, ec: ExecutionContext): Future[JsObject] = {
+  private def powChallenge(state: String, conf: PowConfig)(using env: Env, ec: ExecutionContext): Future[JsObject] = {
     val challenge = Random.alphanumeric.take(16).mkString
     val payload   = Json.obj(
       "state"      -> state,
@@ -666,7 +660,7 @@ class ProofOfWorkPlugin extends NgRequestTransformer {
     }
   }
 
-  private def powVerify(body: JsValue, conf: PowConfig, req: RequestHeader)(implicit env: Env, ec: ExecutionContext): Future[Result] = {
+  private def powVerify(body: JsValue, conf: PowConfig, req: RequestHeader)(using env: Env, ec: ExecutionContext): Future[Result] = {
     val challenge = (body \ "challenge").as[String]
     val nonce     = (body \ "nonce").as[String]
     val hash      = (body \ "hash").as[String]

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/providerscatalog.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/providerscatalog.scala
@@ -1,13 +1,13 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvidersCatalog
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +16,7 @@ object LlmProvidersCatalog {
 
   // Reads the (repeatable and/or comma-separated) `capabilities`/`capability` query params and
   // returns the matching catalog entries. A provider must expose ALL requested capabilities.
-  def handleRequest(ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val requested = (ctx.rawRequest.queryString.getOrElse("capabilities", Seq.empty) ++
       ctx.rawRequest.queryString.getOrElse("capability", Seq.empty))
       .flatMap(_.split(",")).map(_.trim).filter(_.nonEmpty)
@@ -50,7 +50,7 @@ class LlmProvidersCatalog extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     LlmProvidersCatalog.handleRequest(ctx)
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/proxy.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/proxy.scala
@@ -1,18 +1,17 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.{AiPluginRefConfig, AiPluginRefsConfig, AiPluginsKeys, PromptValidatorConfig}
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
 import otoroshi.utils.ReplaceAllWith
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +32,6 @@ object AiLlmProxy {
         case JsObject(str) => str.toString()
         case JsArray(str) => str.toString()
         case JsNull => "null"
-        case _ => "undefined"
       }
     }
     result.parseJson.asOpt[Seq[JsObject]].getOrElse(Seq.empty)
@@ -63,7 +61,7 @@ class AiLlmProxy extends NgBackendCall {
     ().vfuture
   }
 
-  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(implicit ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def call(_jsonBody: JsValue, config: AiPluginRefsConfig, ctx: NgbBackendCallContext)(using ec: ExecutionContext, env: Env): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val jsonBody: JsValue = AiPluginRefsConfig.extractProviderFromModelInBody(_jsonBody, config)
     val provider: Option[AiProvider] = jsonBody.select("provider").asOpt[String].filter(v => config.refs.contains(v)).flatMap { r =>
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(r))
@@ -109,7 +107,7 @@ class AiLlmProxy extends NgBackendCall {
           } else {
             client.call(ChatPrompt(messages), ctx.attrs, jsonBody).map {
               case Left(err) => Left(NgProxyEngineError.NgResultProxyEngineError(Results.BadRequest(err)))
-              case Right(response) => Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.json(env)).withHeaders(response.metadata.cacheHeaders.toSeq: _*)), None))
+              case Right(response) => Right(BackendCallResponse(NgPluginHttpResponse.fromResult(Results.Ok(response.json(env)).withHeaders(response.metadata.cacheHeaders.toSeq*)), None))
             }
           }
         } else {
@@ -129,7 +127,7 @@ class AiLlmProxy extends NgBackendCall {
     }
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     if (ctx.request.hasBody) {
       ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
         try {
@@ -183,7 +181,7 @@ class AiPromptValidator extends NgAccessValidator {
     ().vfuture
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     val config = ctx.cachedConfig(internalName)(PromptValidatorConfig.format).getOrElse(PromptValidatorConfig.default)
     ctx.attrs.get(AiPluginsKeys.PromptValidatorsKey) match {
       case None => ctx.attrs.put(AiPluginsKeys.PromptValidatorsKey -> Seq(config))
@@ -214,7 +212,7 @@ class AiPromptTemplate extends NgRequestTransformer {
     ().vfuture
   }
 
-  override def transformRequest(ctx: NgTransformerRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
+  override def transformRequest(ctx: NgTransformerRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefConfig.format).getOrElse(AiPluginRefConfig.default)
     env.adminExtensions.extension[AiExtension].flatMap(_.states.template(config.ref)) match {
       case None => Left(Results.InternalServerError(Json.obj("error" -> "template not found"))).vfuture // TODO: rewrite error
@@ -261,7 +259,7 @@ class AiPromptContext extends NgRequestTransformer {
     ().vfuture
   }
 
-  override def transformRequest(ctx: NgTransformerRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
+  override def transformRequest(ctx: NgTransformerRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
     val config = ctx.cachedConfig(internalName)(AiPluginRefConfig.format).getOrElse(AiPluginRefConfig.default)
     env.adminExtensions.extension[AiExtension].flatMap(_.states.context(config.ref)) match {
       case None => Left(Results.InternalServerError(Json.obj("error" -> "context not found"))).vfuture // TODO: rewrite error

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/rampart.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/rampart.scala
@@ -1,13 +1,13 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.guardrails.{PlaceholderAllocator, RampartEngine, RampartPiiGuardrail}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.mvc.{Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -62,14 +62,14 @@ object RampartBody {
   }
 
   // redacts PII in raw text. Each call uses a fresh allocator (request and response bodies are independent).
-  def redact(text: String, cfg: RampartBodyRedactorConfig)(implicit env: Env): String = {
+  def redact(text: String, cfg: RampartBodyRedactorConfig)(using env: Env): String = {
     val engine = RampartEngine.get
     val alloc = new PlaceholderAllocator()
     engine.redactText(text, engine.detectAll(text, cfg.minScore, cfg.entities), alloc)
   }
 
   // fail-open: never break the proxy if the model misbehaves, just log and pass the body through unchanged
-  def safeRedact(text: String, cfg: RampartBodyRedactorConfig)(implicit env: Env): String = {
+  def safeRedact(text: String, cfg: RampartBodyRedactorConfig)(using env: Env): String = {
     try { redact(text, cfg) } catch {
       case e: Throwable => logger.error(s"[rampart] body redaction failed, passing body through: ${e.getMessage}", e); text
     }
@@ -96,7 +96,7 @@ class RampartRequestBodyRedactor extends NgRequestTransformer {
   override def transformsResponse: Boolean = false
   override def transformsRequest: Boolean = true
 
-  override def transformRequest(ctx: NgTransformerRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
+  override def transformRequest(ctx: NgTransformerRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
     val config = ctx.cachedConfig(internalName)(RampartBodyRedactorConfig.format).getOrElse(RampartBodyRedactorConfig.default)
     val contentType = ctx.otoroshiRequest.headers.find(_._1.equalsIgnoreCase("Content-Type")).map(_._2)
     if (!ctx.otoroshiRequest.hasBody || !RampartBody.matchesContentType(contentType, config.contentTypes)) {
@@ -133,7 +133,7 @@ class RampartResponseBodyRedactor extends NgRequestTransformer {
   override def transformsResponse: Boolean = true
   override def transformsRequest: Boolean = false
 
-  override def transformResponse(ctx: NgTransformerResponseContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
+  override def transformResponse(ctx: NgTransformerResponseContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
     val config = ctx.cachedConfig(internalName)(RampartBodyRedactorConfig.format).getOrElse(RampartBodyRedactorConfig.default)
     val contentType = ctx.otoroshiResponse.headers.find(_._1.equalsIgnoreCase("Content-Type")).map(_._2)
     if (!RampartBody.matchesContentType(contentType, config.contentTypes)) {
@@ -167,7 +167,7 @@ class RampartBodyRedactionBackend extends NgBackendCall {
   override def configFlow: Seq[String] = RampartBodyRedactorConfig.configFlow
   override def configSchema: Option[JsObject] = RampartBodyRedactorConfig.configSchema
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(RampartBodyRedactorConfig.format).getOrElse(RampartBodyRedactorConfig.default)
     val contentType = ctx.request.headers.find(_._1.equalsIgnoreCase("Content-Type")).map(_._2)
     def respond(redacted: String, applied: Boolean): Either[NgProxyEngineError, BackendCallResponse] = {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/ratelimiting.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/ratelimiting.scala
@@ -1,19 +1,19 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatClient
 import otoroshi.el.GlobalExpressionLanguage
 import otoroshi.env.Env
 import otoroshi.gateway.Errors
 import otoroshi.next.plugins.NgCustomThrottling
-import otoroshi.next.plugins.api._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util._
+import scala.util.*
 
 case class LlmTokensRateLimitingValidatorConfig(windowMillis: String, groupExpr: String, _throttlingQuota: String) extends NgPluginConfig {
   def json: JsValue = LlmTokensRateLimitingValidatorConfig.format.writes(this)
@@ -81,14 +81,14 @@ object LlmTokensRateLimitingValidatorConfig {
 }
 
 object StringImpls {
-  implicit class StringExt(val s: String) extends AnyVal {
+  extension (s: String) {
     def toLongOrElse(default: Long): Long = if (s.isEmpty) default else Try(s.toLong).getOrElse(default)
   }
 }
 
 class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTransformer {
 
-  import StringImpls._
+  import StringImpls.*
 
   override def steps: Seq[NgStep]                = Seq(NgStep.ValidateAccess, NgStep.TransformResponse)
   override def visibility: NgPluginVisibility = NgPluginVisibility.NgUserLand
@@ -113,7 +113,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     ().vfuture
   }
 
-  private def throttlingKey(name: String, group: String, ctx: NgAccessContext)(implicit env: Env): String = {
+  private def throttlingKey(name: String, group: String, ctx: NgAccessContext)(using env: Env): String = {
     NgCustomThrottling.throttlingKey(computeExpr(name, ctx, env), computeExpr(group, ctx, env))
   }
 
@@ -125,20 +125,6 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
       route = ctx.route.some,
       apiKey = ctx.apikey,
       user = ctx.user,
-      context = Map.empty,
-      attrs = ctx.attrs,
-      env = env
-    )
-  }
-
-  private def computeExprAfter(expr: String, ctx: NgAfterRequestContext, env: Env): String = {
-    GlobalExpressionLanguage.apply(
-      value = expr,
-      req = ctx.request.some,
-      service = ctx.route.legacy.some,
-      route = ctx.route.some,
-      user = ctx.attrs.get(otoroshi.plugins.Keys.UserKey),
-      apiKey = ctx.attrs.get(otoroshi.plugins.Keys.ApiKeyKey),
       context = Map.empty,
       attrs = ctx.attrs,
       env = env
@@ -173,7 +159,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     )
   }
 
-  private def updateQuotas(ctx: NgTransformerResponseContext, qconf: LlmTokensRateLimitingValidatorConfig)(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  private def updateQuotas(ctx: NgTransformerResponseContext, qconf: LlmTokensRateLimitingValidatorConfig)(using ec: ExecutionContext, env: Env): Future[Unit] = {
     val group = computeExprAfter(qconf.groupExpr, ctx, env)
     val expr  = computeExprAfter(defaultExpr, ctx, env)
     val windowMillis = computeExprAfter(qconf.windowMillis, ctx, env).trim.toLongOrElse(10000)
@@ -199,7 +185,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     }.getOrElse(().vfuture)
   }
 
-  private def updateQuotas(ctx: NgTransformerErrorContext, qconf: LlmTokensRateLimitingValidatorConfig)(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  private def updateQuotas(ctx: NgTransformerErrorContext, qconf: LlmTokensRateLimitingValidatorConfig)(using ec: ExecutionContext, env: Env): Future[Unit] = {
     val group = computeExprAfter(qconf.groupExpr, ctx, env)
     val expr  = computeExprAfter(defaultExpr, ctx, env)
     val windowMillis = computeExprAfter(qconf.windowMillis, ctx, env).trim.toLongOrElse(10000L)
@@ -227,7 +213,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
   private def withingQuotas(
                              ctx: NgAccessContext,
                              qconf: LlmTokensRateLimitingValidatorConfig
-                           )(implicit ec: ExecutionContext, env: Env): Future[Boolean] = {
+                           )(using ec: ExecutionContext, env: Env): Future[Boolean] = {
     val value = qconf.throttlingQuota(ctx, env)
     val key = throttlingKey(computeExpr(defaultExpr, ctx, env), computeExpr(qconf.groupExpr, ctx, env), ctx)
     // println(s"checking '${key}' under ${value}")
@@ -251,7 +237,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
       }
   }
 
-  private def tooMuchTokens(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  private def tooMuchTokens(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     Errors
       .craftResponseResult(
         "too many tokens used",
@@ -267,7 +253,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
       .map(r => NgAccess.NgDenied(r))
   }
 
-  override def access(ctx: NgAccessContext)(implicit env: Env, ec: ExecutionContext): Future[NgAccess] = {
+  override def access(ctx: NgAccessContext)(using env: Env, ec: ExecutionContext): Future[NgAccess] = {
     val config = ctx.cachedConfig(internalName)(LlmTokensRateLimitingValidatorConfig.format).getOrElse(LlmTokensRateLimitingValidatorConfig.default)
     val windowMillis = computeExpr(config.windowMillis, ctx, env).trim
     ctx.attrs.put(LlmTokensRateLimitingValidatorConfig.LlmTokensRateLimitingValidatorKey -> Map(
@@ -279,7 +265,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     }
   }
 
-  override def transformResponse(ctx: NgTransformerResponseContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
+  override def transformResponse(ctx: NgTransformerResponseContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
     val config = ctx.cachedConfig(internalName)(LlmTokensRateLimitingValidatorConfig.format).getOrElse(LlmTokensRateLimitingValidatorConfig.default)
     updateQuotas(ctx, config).map { _ =>
       val headers = ctx.attrs.get(LlmTokensRateLimitingValidatorConfig.LlmTokensRateLimitingValidatorKey).getOrElse(Map.empty[String, String])
@@ -302,7 +288,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     }
   }
 
-  override def transformError(ctx: NgTransformerErrorContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[NgPluginHttpResponse] = {
+  override def transformError(ctx: NgTransformerErrorContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[NgPluginHttpResponse] = {
     val config = ctx.cachedConfig(internalName)(LlmTokensRateLimitingValidatorConfig.format).getOrElse(LlmTokensRateLimitingValidatorConfig.default)
     updateQuotas(ctx, config).map { _ =>
       val headers = ctx.attrs.get(LlmTokensRateLimitingValidatorConfig.LlmTokensRateLimitingValidatorKey).getOrElse(Map.empty[String, String])
@@ -325,7 +311,7 @@ class LlmTokensRateLimitingValidator extends NgAccessValidator with NgRequestTra
     }
   }
 
-  override def afterRequest(ctx: NgAfterRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Unit] = {
+  override def afterRequest(ctx: NgAfterRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Unit] = {
     // val config = ctx.cachedConfig(internalName)(LlmTokensRateLimitingValidatorConfig.format).getOrElse(LlmTokensRateLimitingValidatorConfig.default)
     // updateQuotas(ctx, config)
     ().vfuture

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/requestmodifier.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/requestmodifier.scala
@@ -1,14 +1,14 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.plugins.AiPromptRequestConfig
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt}
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{Result, Results}
@@ -42,7 +42,7 @@ class AiRequestBodyModifier extends NgRequestTransformer {
     ().vfuture
   }
 
-  override def transformRequest(ctx: NgTransformerRequestContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
+  override def transformRequest(ctx: NgTransformerRequestContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpRequest]] = {
     val config = ctx.cachedConfig(internalName)(AiPromptRequestConfig.format).getOrElse(AiPromptRequestConfig.default)
     if (ctx.otoroshiRequest.hasBody) {
       env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responsegenerator.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responsegenerator.scala
@@ -1,14 +1,14 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt, InputChatMessage}
 import otoroshi.env.Env
 import otoroshi.next.plugins.BodyHelper
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 
 case class AiResponseGeneratorConfig(ref: String = "", _prompt: String = "", promptRef: Option[String] = None, contextRef: Option[String] = None, isResponse: Boolean = false, status: Int = 200, headers: Map[String, String] = Map.empty) extends NgPluginConfig {
   def json: JsValue = AiResponseGeneratorConfig.format.writes(this)
-  def prompt(implicit env: Env): String = promptRef match {
+  def prompt(using env: Env): String = promptRef match {
     case None => _prompt
     case Some(ref) => env.adminExtensions.extension[AiExtension] match {
       case None => _prompt
@@ -26,7 +26,7 @@ case class AiResponseGeneratorConfig(ref: String = "", _prompt: String = "", pro
       }
     }
   }
-  def preChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def preChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -38,7 +38,7 @@ case class AiResponseGeneratorConfig(ref: String = "", _prompt: String = "", pro
       }
     }
   }
-  def postChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def postChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -158,7 +158,7 @@ class AiResponseGenerator extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiResponseGeneratorConfig.format).getOrElse(AiResponseGeneratorConfig.default)
     env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {
       case None => Left(NgProxyEngineError.NgResultProxyEngineError(Results.InternalServerError(Json.obj("error" -> "provider not found")))).vfuture // TODO: rewrite error
@@ -177,15 +177,15 @@ class AiResponseGenerator extends NgBackendCall {
                 .getOrElse(Map("Content-Type" -> "application/json"))
               val contentType = headers.getIgnoreCase("Content-Type").getOrElse("application/json")
               Right(BackendCallResponse(NgPluginHttpResponse.fromResult(
-                Results.Status(status)(body).withHeaders(headers.toSeq: _*).as(contentType)
+                Results.Status(status)(body).withHeaders(headers.toSeq*).as(contentType)
               ), None))
             }
-            case Right(resp) if !config.isResponse => {
+            case Right(resp) => {
               val status = config.status
               val headers = config.headers
               val contentType = headers.getIgnoreCase("Content-Type").orElse(headers.get("content-type")).getOrElse("application/json")
               Right(BackendCallResponse(NgPluginHttpResponse.fromResult(
-                Results.Status(status)(resp.headGeneration.message.content.byteString).withHeaders(headers.toSeq: _*).as(contentType)
+                Results.Status(status)(resp.headGeneration.message.content.byteString).withHeaders(headers.toSeq*).as(contentType)
               ), None))
             }
           }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responseheaders.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responseheaders.scala
@@ -1,13 +1,13 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatClient
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.ChatClientWithCostsTracking
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.mvc.Result
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -102,7 +102,7 @@ class AiLlmResponseHeaders extends NgRequestTransformer {
   override def transformsResponse: Boolean = true
   override def transformsRequest: Boolean = false
 
-  override def transformResponse(ctx: NgTransformerResponseContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
+  override def transformResponse(ctx: NgTransformerResponseContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiLlmResponseHeadersConfig.format).getOrElse(AiLlmResponseHeadersConfig.default)
     val headers = AiLlmResponseHeaders.computeHeaders(ctx.attrs, config.prefix, config.includeCosts)
     if (headers.isEmpty) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responsemodifier.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/responsemodifier.scala
@@ -1,14 +1,14 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt, InputChatMessage}
 import otoroshi.env.Env
 import otoroshi.next.plugins.BodyHelper
-import otoroshi.next.plugins.api._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Result, Results}
 
 import java.util.regex.Pattern.CASE_INSENSITIVE
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try}
 
 case class AiResponseBodyModifierConfig(ref: String = "", _prompt: String = "", promptRef: Option[String] = None, contextRef: Option[String] = None, extractor: Option[String] = None, isResponse: Boolean = false) extends NgPluginConfig {
   def json: JsValue = AiResponseBodyModifierConfig.format.writes(this)
-  def prompt(implicit env: Env): String = promptRef match {
+  def prompt(using env: Env): String = promptRef match {
     case None => _prompt
     case Some(ref) => env.adminExtensions.extension[AiExtension] match {
       case None => _prompt
@@ -28,7 +28,7 @@ case class AiResponseBodyModifierConfig(ref: String = "", _prompt: String = "", 
       }
     }
   }
-  def preChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def preChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -40,7 +40,7 @@ case class AiResponseBodyModifierConfig(ref: String = "", _prompt: String = "", 
       }
     }
   }
-  def postChatMessages(implicit env: Env): Seq[InputChatMessage] = {
+  def postChatMessages(using env: Env): Seq[InputChatMessage] = {
     contextRef match {
       case None => Seq.empty
       case Some(ref) => env.adminExtensions.extension[AiExtension] match {
@@ -157,7 +157,7 @@ class AiResponseBodyModifier extends NgRequestTransformer {
     ().vfuture
   }
 
-  override def transformResponse(ctx: NgTransformerResponseContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
+  override def transformResponse(ctx: NgTransformerResponseContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[Result, NgPluginHttpResponse]] = {
     val config = ctx.cachedConfig(internalName)(AiResponseBodyModifierConfig.format).getOrElse(AiResponseBodyModifierConfig.default)
     env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {
       case None => Left(Results.InternalServerError(Json.obj("error" -> "provider not found"))).vfuture // TODO: rewrite error
@@ -183,7 +183,7 @@ class AiResponseBodyModifier extends NgRequestTransformer {
                       body = body.chunks(32 * 1024)
                     ).rightf
                   }
-                  case None if !config.isResponse => {
+                  case None => {
                     val content = resp.headGeneration.message.content
                     ctx.otoroshiResponse.copy(
                       headers = ctx.otoroshiResponse.headers ++ Map("Transfer-Encoding" -> s"chunked") - "Content-Length" - "content-length",

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/search.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/search.scala
@@ -1,15 +1,15 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.{AiMetrics, SearchEngineSearchOptions}
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.SearchEngine
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,7 +51,7 @@ object SearchEngineProxyConfig {
     }
   }
 
-  def resolveProvider(jsonBody: JsObject, config: SearchEngineProxyConfig)(implicit ec: ExecutionContext, env: Env): Option[SearchEngine] = {
+  def resolveProvider(jsonBody: JsObject, config: SearchEngineProxyConfig)(using ec: ExecutionContext, env: Env): Option[SearchEngine] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     jsonBody.select("provider").asOpt[String]
       .filter(v => config.refs.contains(v))
@@ -61,7 +61,7 @@ object SearchEngineProxyConfig {
 }
 
 object SearchEngineProxy {
-  def handleRequest(config: SearchEngineProxyConfig, ctx: NgbBackendCallContext)(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  def handleRequest(config: SearchEngineProxyConfig, ctx: NgbBackendCallContext)(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val jsonBody: JsObject = (if (bodyRaw.isEmpty) Json.obj() else bodyRaw.utf8String.parseJson).asObject
       SearchEngineProxyConfig.resolveProvider(jsonBody, config) match {
@@ -106,7 +106,7 @@ class SearchEngineProxy extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val config = ctx.cachedConfig(internalName)(SearchEngineProxyConfig.format).getOrElse(SearchEngineProxyConfig.default)
     SearchEngineProxy.handleRequest(config, ctx)
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/videosgen.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/videosgen.scala
@@ -1,15 +1,15 @@
 package otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.VideoModelClientTextToVideoInputOptions
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.VideoModel
 import otoroshi.env.Env
-import otoroshi.next.plugins.api._
+import otoroshi.next.plugins.api.*
 import otoroshi.next.proxy.NgProxyEngineError
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.Results
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -48,7 +48,7 @@ object VideosGenConfig {
       case Success(value) => JsSuccess(value)
     }
   }
-  def getProvidersMap(config: VideosGenConfig)(implicit ec: ExecutionContext, env: Env): (Map[String, VideoModel], Map[String, VideoModel]) = {
+  def getProvidersMap(config: VideosGenConfig)(using ec: ExecutionContext, env: Env): (Map[String, VideoModel], Map[String, VideoModel]) = {
     val ext = env.adminExtensions.extension[AiExtension].get
     val providers = config.refs.flatMap(ref => ext.states.videoModel(ref))
     val providersByName = providers.map { provider =>
@@ -59,7 +59,7 @@ object VideosGenConfig {
     (providersById, providersByName)
   }
 
-  def extractProviderFromModelInBody(_jsonBody: JsValue, config: VideosGenConfig)(implicit ec: ExecutionContext, env: Env): JsValue = {
+  def extractProviderFromModelInBody(_jsonBody: JsValue, config: VideosGenConfig)(using ec: ExecutionContext, env: Env): JsValue = {
     _jsonBody.select("model").asOpt[String] match {
       case Some(value) if value.contains("###") => {
         val parts = value.split("###")
@@ -117,7 +117,7 @@ class VideosGen extends NgBackendCall {
     ().vfuture
   }
 
-  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(implicit env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
+  override def callBackend(ctx: NgbBackendCallContext, delegates: () => Future[Either[NgProxyEngineError, BackendCallResponse]])(using env: Env, ec: ExecutionContext, mat: Materializer): Future[Either[NgProxyEngineError, BackendCallResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension].get
     ctx.request.body.runFold(ByteString.empty)(_ ++ _).flatMap { bodyRaw =>
       val _jsonBody = bodyRaw.utf8String.parseJson

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/websocketvalidator.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/plugins/websocketvalidator.scala
@@ -4,8 +4,8 @@ import com.cloud.apim.otoroshi.extensions.aigateway.plugins.AiPromptRequestConfi
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessage, ChatPrompt}
 import otoroshi.env.Env
 import otoroshi.next.plugins.RejectStrategy
-import otoroshi.next.plugins.api._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.plugins.api.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.http.websocket.{CloseCodes, TextMessage}
 import play.api.libs.json.{JsObject, Json}
@@ -13,6 +13,7 @@ import play.api.libs.json.{JsObject, Json}
 import java.util.regex.Pattern.CASE_INSENSITIVE
 import java.util.regex.{MatchResult, Matcher, Pattern}
 import scala.concurrent.{ExecutionContext, Future}
+import org.apache.pekko.stream.Materializer
 
 class AiWebsocketMessageValidator extends NgWebsocketValidatorPlugin {
 
@@ -37,9 +38,9 @@ class AiWebsocketMessageValidator extends NgWebsocketValidatorPlugin {
     ().vfuture
   }
 
-  override def onRequestMessage(ctx: NgWebsocketPluginContext, message: WebsocketMessage)(implicit env: Env, ec: ExecutionContext): Future[Either[NgWebsocketError, WebsocketMessage]] = {
+  override def onRequestMessage(ctx: NgWebsocketPluginContext, message: WebsocketMessage)(using env: Env, ec: ExecutionContext): Future[Either[NgWebsocketError, WebsocketMessage]] = {
     val config = ctx.cachedConfig(internalName)(AiPromptRequestConfig.format).getOrElse(AiPromptRequestConfig())
-    implicit val mat = env.otoroshiMaterializer
+    given mat: Materializer = env.otoroshiMaterializer
     if (message.isText) {
       message.str().flatMap { str =>
         env.adminExtensions.extension[AiExtension].flatMap(_.states.provider(config.ref)) match {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/Api.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/Api.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatResponseMetadataUsage
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSResponse
@@ -19,13 +19,13 @@ trait ApiClient[Resp, Chunk] {
   def supportsStreaming: Boolean
   def supportsCompletion: Boolean
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, Resp]]
-  def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, Resp]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, Resp]]
+  def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, Resp]] = {
     call(method, path, body, acc)
   }
 
-  def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[Chunk, _], WSResponse)]]
-  def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[Chunk, _], WSResponse)]] = {
+  def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[Chunk, ?], WSResponse)]]
+  def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[Chunk, ?], WSResponse)]] = {
     stream(method, path, body, acc)
   }
 }
@@ -36,8 +36,8 @@ trait NoStreamingApiClient[Resp] {
   def supportsCompletion: Boolean
   final def supportsStreaming: Boolean = false
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, Resp]]
-  def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, Resp]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, Resp]]
+  def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, Resp]] = {
     call(method, path, body, acc)
   }
 }
@@ -63,7 +63,7 @@ object ProviderHelpers {
   def logBadResponse(from: String, resp: WSResponse): Unit = {
     AiExtension.logger.error(s"Response with error from '${from}': ${resp.status} - ${resp.body}")
   }
-  def logCall(from: String, method: String, url: String, body: Option[JsValue] = None, opts: Map[String, String] = Map.empty)(implicit env: Env): Unit = {
+  def logCall(from: String, method: String, url: String, body: Option[JsValue] = None, opts: Map[String, String] = Map.empty)(using env: Env): Unit = {
     if (env.isDev || AiExtension.logger.isDebugEnabled) {
       val msg = s"calling provider '${from}' - ${method} - ${url} - ${opts} - ${body.map(_.prettify).getOrElse("")}"
       if (env.isDev) {
@@ -74,7 +74,7 @@ object ProviderHelpers {
       }
     }
   }
-  def logStream(from: String, method: String, url: String, body: Option[JsValue] = None, opts: Map[String, String] = Map.empty)(implicit env: Env): Unit = {
+  def logStream(from: String, method: String, url: String, body: Option[JsValue] = None, opts: Map[String, String] = Map.empty)(using env: Env): Unit = {
     if (env.isDev || AiExtension.logger.isDebugEnabled) {
       val msg = s"stream provider '${from}' - ${method} - ${url} - ${opts} - ${body.map(_.prettify).getOrElse("")}"
       if (env.isDev) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/alphaedge.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/alphaedge.scala
@@ -1,17 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, Multipart}
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, Multipart}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 
 // AlphaEdge AI - https://api-docs.alphaedge-ai.com
 // AlphaEdge only exposes "file -> text" models:
@@ -26,9 +26,9 @@ object AlphaEdgeApi {
 
 class AlphaEdgeApi(baseUrl: String = AlphaEdgeApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("AlphaEdge", method, url, body)(env)
+    ProviderHelpers.logCall("AlphaEdge", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -44,10 +44,10 @@ class AlphaEdgeApi(baseUrl: String = AlphaEdgeApi.baseUrl, token: String, timeou
       .execute()
   }
 
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("AlphaEdge", method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall("AlphaEdge", method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -83,7 +83,7 @@ class AlphaEdgeAudioModelClient(val api: AlphaEdgeApi, val sttOptions: AlphaEdge
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = false
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.asOpt[Seq[JsObject]].getOrElse(Seq.empty)
@@ -98,11 +98,11 @@ class AlphaEdgeAudioModelClient(val api: AlphaEdgeApi, val sttOptions: AlphaEdge
     }
   }
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     List.empty.rightf
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model).getOrElse(AlphaEdgeApi.defaultAudioModel)
     val diarization = rawBody.select("enable_diarization").asOptBoolean.orElse(sttOptions.enableDiarization)
     val postcorrect = rawBody.select("enable_postcorrect").asOptBoolean.orElse(sttOptions.enablePostcorrect)
@@ -123,7 +123,7 @@ class AlphaEdgeAudioModelClient(val api: AlphaEdgeApi, val sttOptions: AlphaEdge
         HttpEntity(postcorrect.toString.byteString),
       )
     }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", s"/models/${model}/transcript", form).map { response =>
       if (response.status == 200) {
         AudioTranscriptionResponse(response.json.select("text").asString, AudioTranscriptionResponseMetadata.empty).right
@@ -156,7 +156,7 @@ class AlphaEdgeChatClient(api: AlphaEdgeApi, options: AlphaEdgeChatClientOptions
 
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(options.model.some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.asOpt[Seq[JsObject]].getOrElse(Seq.empty)
@@ -172,7 +172,7 @@ class AlphaEdgeChatClient(api: AlphaEdgeApi, options: AlphaEdgeChatClientOptions
     mediaType.split("/").lastOption.map(_.split(";").head.trim).filter(_.nonEmpty).getOrElse("bin")
 
   // OCR needs a single image/pdf file. We extract it from the first image or pdf content part of the prompt.
-  private def resolveOcrFile(prompt: ChatPrompt)(implicit ec: ExecutionContext, env: Env): Future[Option[(ByteString, String, String)]] = {
+  private def resolveOcrFile(prompt: ChatPrompt)(using ec: ExecutionContext, env: Env): Future[Option[(ByteString, String, String)]] = {
     val parts = prompt.messages.flatMap(_.contentParts)
     parts.collectFirst {
       case img: ChatMessageContent.ImageContent => (img.data, img.url, img.mediaType, s"image.${fileExtension(img.mediaType)}")
@@ -185,7 +185,7 @@ class AlphaEdgeChatClient(api: AlphaEdgeApi, options: AlphaEdgeChatClientOptions
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject
     val finalModel = computeModel(originalBody).getOrElse(options.model)
     val pdfPassword = (if (options.allowConfigOverride) obody.select("pdf_password").asOptString else None).orElse(options.pdfPassword)
@@ -203,7 +203,7 @@ class AlphaEdgeChatClient(api: AlphaEdgeApi, options: AlphaEdgeChatClientOptions
         ).applyOnWithOpt(pdfPassword) {
           case (list, pwd) => list :+ Multipart.FormData.BodyPart("pdf_password", HttpEntity(pwd.byteString))
         }
-        val form = Multipart.FormData(parts: _*)
+        val form = Multipart.FormData(parts*)
         api.rawCallForm("POST", s"/models/${finalModel}/ocr", form).map { resp =>
           if (resp.status == 200) {
             val body = resp.json
@@ -224,7 +224,6 @@ class AlphaEdgeChatClient(api: AlphaEdgeApi, options: AlphaEdgeChatClientOptions
                 val arr = obj.select("ai").asOpt[Seq[JsObject]].getOrElse(Seq.empty)
                 obj ++ Json.obj("ai" -> (arr ++ Seq(slug)))
               }
-              case Some(other) => other
               case None => Json.obj("ai" -> Seq(slug))
             }
             val gen = ChatGeneration(ChatMessage.output("assistant", text, None, Json.obj("role" -> "assistant", "content" -> text)))
@@ -253,7 +252,7 @@ object AlphaEdgeOcrModelClientOptions {
 
 class AlphaEdgeOcrModelClient(val api: AlphaEdgeApi, val options: AlphaEdgeOcrModelClientOptions, id: String) extends OcrModelClient {
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.asOpt[Seq[JsObject]].getOrElse(Seq.empty)
@@ -268,7 +267,7 @@ class AlphaEdgeOcrModelClient(val api: AlphaEdgeApi, val options: AlphaEdgeOcrMo
     }
   }
 
-  private def resolveBytes(opts: OcrModelClientInputOptions)(implicit ec: ExecutionContext, env: Env): Future[Option[(ByteString, String, String)]] = {
+  private def resolveBytes(opts: OcrModelClientInputOptions)(using ec: ExecutionContext, env: Env): Future[Option[(ByteString, String, String)]] = {
     val ct = opts.fileContentType.getOrElse("application/octet-stream")
     val name = opts.fileName.getOrElse(if (ct.startsWith("image/")) s"image.${ct.split("/").lastOption.getOrElse("png")}" else "document.pdf")
     opts.bytes match {
@@ -280,7 +279,7 @@ class AlphaEdgeOcrModelClient(val api: AlphaEdgeApi, val options: AlphaEdgeOcrMo
     }
   }
 
-  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
+  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
     val model = opts.model.getOrElse(options.model)
     val pdfPassword = rawBody.select("pdf_password").asOptString.orElse(options.pdfPassword)
     resolveBytes(opts).flatMap {
@@ -292,7 +291,7 @@ class AlphaEdgeOcrModelClient(val api: AlphaEdgeApi, val options: AlphaEdgeOcrMo
         ).applyOnWithOpt(pdfPassword) {
           case (list, pwd) => list :+ Multipart.FormData.BodyPart("pdf_password", HttpEntity(pwd.byteString))
         }
-        val form = Multipart.FormData(parts: _*)
+        val form = Multipart.FormData(parts*)
         api.rawCallForm("POST", s"/models/${model}/ocr", form).map { resp =>
           if (resp.status == 200) {
             val text = resp.json.select("text").asString

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/anthropic.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/anthropic.scala
@@ -1,17 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
-import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AnthropicApiResponseChoiceMessageToolCall, GenericApiResponseChoiceMessageToolCall, LlmFunctions}
-import diffson.DiffOps
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AnthropicApiResponseChoiceMessageToolCall, LlmFunctions}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.matching.Regex
@@ -119,9 +119,9 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
   override def supportsCompletion: Boolean = true
   override def supportsStreaming: Boolean = true
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Anthropic", method, url, body)(env)
+    ProviderHelpers.logCall("Anthropic", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -142,17 +142,17 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
       .execute()
   }
 
-  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, AnthropicApiResponse]] = {
+  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, AnthropicApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("Anthropic", r, env) { resp =>
         acc.updateAnthropic(resp.json.select("usage").asOpt[JsObject])
-        AnthropicApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        AnthropicApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
-  def raw_stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, _], WSResponse)]] = {
+  def raw_stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream(providerName, method, url, body)(env)
+    ProviderHelpers.logStream(providerName, method, url, body)(using env)
     val messageRef = new AtomicReference[JsValue]()
     env.Ws
       .url(s"${baseUrl}${path}")
@@ -203,7 +203,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
       })
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, ?], WSResponse)]] = {
     raw_stream(method, path, body, acc)
       .map {
         case Left(e) => Left(e)
@@ -216,7 +216,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
       }
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, AnthropicApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, AnthropicApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -230,7 +230,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) //.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.body.select("content").as[Seq[JsObject]].filter(o => o.select("type").asOptString.contains("tool_use"))
-              LlmFunctions.callToolsAnthropic(toolCalls.map(tc => AnthropicApiResponseChoiceMessageToolCall(tc)), mcpConnectors, providerName, attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsAnthropic(toolCalls.map(tc => AnthropicApiResponseChoiceMessageToolCall(tc)), mcpConnectors, providerName, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   val newMessages: Seq[JsValue] = messages ++ callResps
                   val newBody = body.asObject ++ Json.obj("messages" -> JsArray(newMessages))
@@ -247,7 +247,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
     }
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[AnthropicApiResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -268,7 +268,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
               // println("start tool_user")
               isToolCall = true
               toolCalls = toolCalls :+ AnthropicChatResponseChunkChoiceDeltaToolCall(chunk.choices.head.contentBlockObj)
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.stop_tool_use) {
@@ -306,7 +306,7 @@ class AnthropicApi(baseUrl: String = AnthropicApi.baseUrl, token: String, anthro
                   a
               }
               //println("calling !!!")
-              val a: Future[Either[JsValue, (Source[AnthropicApiResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsAnthropic(calls, mcpConnectors, providerName, attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[AnthropicApiResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsAnthropic(calls, mcpConnectors, providerName, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -429,7 +429,7 @@ class AnthropicChatClient(api: AnthropicApi, options: AnthropicChatClientOptions
 
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(options.model.some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/v1/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -562,7 +562,7 @@ class AnthropicChatClient(api: AnthropicApi, options: AnthropicChatClientOptions
     result.toList
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody).applyOn(cleanupDeprecatedSamplingParams)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -611,7 +611,6 @@ class AnthropicChatClient(api: AnthropicApi, options: AnthropicChatClientOptions
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         val role = resp.body.select("role").asOpt[String].getOrElse("assistant")
@@ -652,7 +651,7 @@ class AnthropicChatClient(api: AnthropicApi, options: AnthropicChatClientOptions
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody).applyOn(cleanupDeprecatedSamplingParams)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -707,7 +706,6 @@ class AnthropicChatClient(api: AnthropicApi, options: AnthropicChatClientOptions
                 val newArr = arr ++ Seq(slug)
                 obj ++ Json.obj("ai" -> newArr)
               }
-              case Some(other) => other
               case None => Json.obj("ai" -> Seq(slug))
             }
             true

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/azureopenai.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/azureopenai.scala
@@ -1,16 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpEntity, Multipart}
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -166,9 +167,9 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
   override def supportsStreaming: Boolean = true
   override def supportsCompletion: Boolean = false
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${AzureOpenAiApi.url(resourceName, deploymentId, version, path)}"
-    ProviderHelpers.logCall("AzureOpenai", method, url, body)(env)
+    ProviderHelpers.logCall("AzureOpenai", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -190,10 +191,10 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
       .execute()
   }
 
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${AzureOpenAiApi.url(resourceName, deploymentId, version, path)}"
-    ProviderHelpers.logCall("AzureOpenai", method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall("AzureOpenai", method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -213,9 +214,9 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
   }
 
   /** raw streamed POST, used by the native /responses path */
-  def rawStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${AzureOpenAiApi.url(resourceName, deploymentId, version, path)}"
-    ProviderHelpers.logStream("AzureOpenai", method, url, body)(env)
+    ProviderHelpers.logStream("AzureOpenai", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -237,15 +238,15 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
       .stream()
   }
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, AzureOpenAiApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, AzureOpenAiApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("AzureOpenai", r, env) { resp =>
         acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-        AzureOpenAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        AzureOpenAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, AzureOpenAiApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, AzureOpenAiApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -259,7 +260,7 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) // .map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "azure", attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "azure", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -276,9 +277,9 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
     }
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${AzureOpenAiApi.url(resourceName, deploymentId, version, path)}"
-    ProviderHelpers.logStream("AzureOpenai", method, url, body)(env)
+    ProviderHelpers.logStream("AzureOpenai", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -319,7 +320,7 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
       })
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -332,12 +333,11 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
           var isToolCallEnded = false
           var toolCalls: Seq[AzureOpenAiChatResponseChunkChoiceDeltaToolCall] = Seq.empty
           var toolCallArgs: scala.collection.mutable.ArraySeq[String] = scala.collection.mutable.ArraySeq.empty
-          var toolCallUsage: AzureOpenAiChatResponseChunkUsage = null
           val newSource = res._1.flatMapConcat { chunk =>
             if (!isToolCall && chunk.choices.exists(_.delta.exists(_.tool_calls.nonEmpty))) {
               isToolCall = true
               toolCalls = chunk.choices.head.delta.head.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.finish_reason.contains("tool_calls")) {
@@ -356,12 +356,11 @@ class AzureOpenAiApi(val resourceName: String, val deploymentId: String, val ver
                 }}
               Source.empty
             } else if (isToolCall && isToolCallEnded) {
-              toolCallUsage = chunk.usage.get
               val calls = toolCalls.zipWithIndex.map {
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "azure", attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[AzureOpenAiChatResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "azure", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -523,10 +522,10 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
     mcpExcludeFunctions = options.mcpExcludeFunctions,
     maxFunctionCalls = options.maxFunctionCalls,
   )
-  override protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/responses", withModelForV1(body.asObject).some)
-  override protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/responses", (withModelForV1(body.asObject) ++ Json.obj("stream" -> true)).some)
+  override protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/responses", withModelForV1(body.asObject).some)
+  override protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/responses", (withModelForV1(body.asObject) ++ Json.obj("stream" -> true)).some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -536,7 +535,7 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = withModelForV1(if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -584,7 +583,6 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -596,7 +594,7 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = withModelForV1(if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -647,7 +645,6 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
               true
@@ -687,7 +684,7 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider" - "prompt"
     val mergedOptions = withModelForV1(if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall)
     val startTime = System.currentTimeMillis()
@@ -725,7 +722,6 @@ class AzureOpenAiChatClient(api: AzureOpenAiApi, options: AzureOpenAiChatClientO
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -748,7 +744,7 @@ class AzureOpenAiEmbeddingModelClient(val api: AzureOpenAiApi, val options: JsOb
     opts: EmbeddingClientInputOptions,
     rawBody: JsObject,
     attrs: TypedMap
-  )(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  )(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     api.rawCall("POST", "/embeddings", (options ++ Json.obj("input" -> opts.input)).some).map { resp =>
       if (resp.status == 200) {
         val deployment = api.deploymentId
@@ -782,7 +778,7 @@ class AzureOpenAIAudioModelClient(val api: AzureOpenAiApi, val ttsOptions: OpenA
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = translationOptions.enabled
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
     Right(
       List(
         AudioGenModel("tts", "tts"),
@@ -792,11 +788,11 @@ class AzureOpenAIAudioModelClient(val api: AzureOpenAiApi, val ttsOptions: OpenA
     ).vfuture
   }
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     List.empty.rightf
   }
 
-  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(translationOptions.model)
     val prompt = opts.prompt.orElse(translationOptions.prompt)
     val responseFormat = opts.responseFormat.orElse(translationOptions.responseFormat)
@@ -831,18 +827,18 @@ class AzureOpenAIAudioModelClient(val api: AzureOpenAiApi, val ttsOptions: OpenA
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/audio/translations", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
     }
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val instructionsOpt: Option[String] = opts.instructions.orElse(ttsOptions.instructions)
     val responseFormatOpt: Option[String] = opts.responseFormat.orElse(ttsOptions.responseFormat)
     val speedOpt: Option[Double] = opts.speed.orElse(ttsOptions.speed)
@@ -869,7 +865,7 @@ class AzureOpenAIAudioModelClient(val api: AzureOpenAiApi, val ttsOptions: OpenA
     }
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val language = opts.language.orElse(sttOptions.language)
     val prompt = opts.prompt.orElse(sttOptions.prompt)
@@ -910,11 +906,11 @@ class AzureOpenAIAudioModelClient(val api: AzureOpenAiApi, val ttsOptions: OpenA
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/audio/transcriptions", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
@@ -949,7 +945,7 @@ class AzureOpenAiImageModelClient(val api: AzureOpenAiApi, val genOptions: Azure
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = false
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel = opts.model.orElse(genOptions.model).getOrElse("gpt-image-1")
     val finalSize: String = opts.size.orElse(genOptions.size).getOrElse("1024x1024").toLowerCase match {
       case "1024x1024" => "1024x1024"
@@ -976,7 +972,7 @@ class AzureOpenAiImageModelClient(val api: AzureOpenAiApi, val genOptions: Azure
 
     api.rawCall("POST", "/images/generations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created").asOpt[Long].getOrElse(-1L),
           images = resp.json.select("data").as[Seq[JsObject]].map(o => ImagesGen(o.select("b64_json").asOpt[String], o.select("revised_prompt").asOpt[String], o.select("url").asOpt[String])),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/chromadb_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/chromadb_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object ChromaDbEmbeddingStoreClient {
   lazy val logger = Logger("ChromaDbEmbeddingStoreClient")
@@ -32,10 +33,10 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
     }
   }
 
-  private def getOrCreateCollection()(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, String]] = {
+  private def getOrCreateCollection()(using ec: ExecutionContext, env: Env): Future[Either[JsValue, String]] = {
     env.Ws
       .url(s"$baseUrl/api/v1/collections/$collectionName?tenant=$tenant&database=$database")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .flatMap { resp =>
@@ -44,7 +45,7 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
         } else {
           env.Ws
             .url(s"$baseUrl/api/v1/collections?tenant=$tenant&database=$database")
-            .withHttpHeaders(headers: _*)
+            .withHttpHeaders(headers*)
             .withRequestTimeout(timeout)
             .post(Json.obj(
               "name" -> collectionName,
@@ -54,20 +55,20 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
               if (createResp.status == 200 || createResp.status == 201) {
                 Right(createResp.json.select("id").asString)
               } else {
-                Left(Json.obj("error" -> s"ChromaDB collection error: ${createResp.status}", "body" -> createResp.body))
+                Left(Json.obj("error" -> s"ChromaDB collection error: ${createResp.status}", "body" -> (createResp.body: String)))
               }
             }
         }
       }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getOrCreateCollection().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(collectionId) =>
         env.Ws
           .url(s"$baseUrl/api/v1/collections/$collectionId/add")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .post(Json.obj(
             "ids" -> Json.arr(options.id),
@@ -78,19 +79,19 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
             if (resp.status == 200 || resp.status == 201) {
               Right(())
             } else {
-              Left(Json.obj("error" -> s"ChromaDB add error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"ChromaDB add error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getOrCreateCollection().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(collectionId) =>
         env.Ws
           .url(s"$baseUrl/api/v1/collections/$collectionId/delete")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .post(Json.obj(
             "ids" -> Json.arr(options.id)
@@ -99,19 +100,19 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
             if (resp.status == 200) {
               Right(())
             } else {
-              Left(Json.obj("error" -> s"ChromaDB delete error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"ChromaDB delete error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     getOrCreateCollection().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(collectionId) =>
         env.Ws
           .url(s"$baseUrl/api/v1/collections/$collectionId/query")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .post(Json.obj(
             "query_embeddings" -> Json.arr(Json.toJson(options.embedding.vector)),
@@ -139,7 +140,7 @@ class ChromaDbEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
               }
               Right(EmbeddingSearchResponse(matches))
             } else {
-              Left(Json.obj("error" -> s"ChromaDB query error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"ChromaDB query error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/cloudflare.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/cloudflare.scala
@@ -1,13 +1,14 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsObject, JsValue, Json}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 case class CloudflareApiResponse(status: Int, headers: Map[String, String], body: JsValue) {
   def json: JsValue = Json.obj(
@@ -27,9 +28,9 @@ class CloudflareApi(val accountId: String, val modelName: String, token: String,
   override def supportsTools: Boolean = false
   override def supportsCompletion: Boolean = false
 
-  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, CloudflareApiResponse]] = {
+  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, CloudflareApiResponse]] = {
     val url = s"${CloudflareApi.url(accountId, modelName)}"
-    ProviderHelpers.logCall("Cloudflare", method, url, body)(env)
+    ProviderHelpers.logCall("Cloudflare", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -45,7 +46,7 @@ class CloudflareApi(val accountId: String, val modelName: String, token: String,
       .execute()
       .map(r => ProviderHelpers.wrapResponse("Cloudflare", r, env) { resp =>
         acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-        CloudflareApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        CloudflareApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 }
@@ -101,7 +102,7 @@ class CloudflareChatClient(api: CloudflareApi, options: CloudflareChatClientOpti
 
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(api.modelName.some)
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val startTime = System.currentTimeMillis()
@@ -138,7 +139,6 @@ class CloudflareChatClient(api: CloudflareApi, options: CloudflareChatClientOpti
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         val role = resp.body.select("role").asOpt[String].getOrElse("assistant")

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/cohere.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/cohere.scala
@@ -1,15 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -94,9 +95,9 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
   override def supportsCompletion: Boolean = false
   override def supportsStreaming: Boolean = true
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Cohere", method, url, body)(env)
+    ProviderHelpers.logCall("Cohere", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -112,17 +113,17 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
       .execute()
   }
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, CohereAiApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, CohereAiApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("Cohere", r, env) { resp =>
         acc.updateCohere(resp.json.select("usage").asOpt[JsObject])
-        CohereAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        CohereAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[CohereAiApiResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[CohereAiApiResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream(providerName, method, url, body)(env)
+    ProviderHelpers.logStream(providerName, method, url, body)(using env)
     val messageStartRef = new AtomicReference[JsValue]()
     val messageEndRef = new AtomicReference[JsValue]()
     env.Ws
@@ -167,8 +168,8 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
       })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, CohereAiApiResponse]] = {
-      if (currentCallCounter >= maxCalls) {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, CohereAiApiResponse]] = {
+    if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
     // TODO: accumulate consumptions ???
@@ -182,7 +183,7 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) //.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsCohere(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, providerName, fmap, attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsCohere(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, providerName, fmap, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -201,7 +202,7 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
     }
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[CohereAiApiResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[CohereAiApiResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -222,7 +223,7 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
             if (!isToolCall && chunk.tool_call_start) {
               isToolCall = true
               toolCalls = toolCalls :+ chunk.choices.head.delta.get.message.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.tool_call_end) { //chunk.choices.head.finish_reason.contains("TOOL_CALL")) {
@@ -249,7 +250,7 @@ class CohereAiApi(baseUrl: String = CohereAiApi.baseUrl, token: String, timeout:
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[CohereAiApiResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsCohere(calls, mcpConnectors, providerName, fmap, attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[CohereAiApiResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsCohere(calls, mcpConnectors, providerName, fmap, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -366,7 +367,7 @@ class CohereAiChatClient(api: CohereAiApi, options: CohereAiChatClientOptions, i
 
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(options.model.some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/v1/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("models").as[List[JsObject]].map(obj => obj.select("name").asString))
@@ -376,7 +377,7 @@ class CohereAiChatClient(api: CohereAiApi, options: CohereAiChatClientOptions, i
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -422,7 +423,6 @@ class CohereAiChatClient(api: CohereAiApi, options: CohereAiChatClientOptions, i
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("message").asOpt[JsObject].map { obj =>
@@ -436,7 +436,7 @@ class CohereAiChatClient(api: CohereAiApi, options: CohereAiChatClientOptions, i
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -484,7 +484,6 @@ class CohereAiChatClient(api: CohereAiApi, options: CohereAiChatClientOptions, i
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
               true
@@ -522,7 +521,7 @@ object CohereAiEmbeddingModelClientOptions {
 
 class CohereAiEmbeddingModelClient(val api: CohereAiApi, val options: CohereAiEmbeddingModelClientOptions, id: String) extends EmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     api.rawCall("POST", "/v2/embed", (options.raw ++ Json.obj("texts" -> opts.input, "model" -> finalModel, "input_type" -> "classification", "embedding_types" -> Json.arr("float"))).some).map { resp =>
       if (resp.status == 200) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elasticsearch_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elasticsearch_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object ElasticsearchEmbeddingStoreClient {
   lazy val logger = Logger("ElasticsearchEmbeddingStoreClient")
@@ -40,10 +41,10 @@ class ElasticsearchEmbeddingStoreClient(val config: JsObject, _storeId: String) 
     base ++ auth
   }
 
-  private def ensureIndex()(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  private def ensureIndex()(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .head()
       .flatMap { resp =>
@@ -52,7 +53,7 @@ class ElasticsearchEmbeddingStoreClient(val config: JsObject, _storeId: String) 
         } else {
           env.Ws
             .url(s"$baseUrl/$index")
-            .withHttpHeaders(headers: _*)
+            .withHttpHeaders(headers*)
             .withRequestTimeout(timeout)
             .put(Json.obj(
               "mappings" -> Json.obj(
@@ -72,20 +73,20 @@ class ElasticsearchEmbeddingStoreClient(val config: JsObject, _storeId: String) 
               if (createResp.status == 200 || createResp.status == 201) {
                 Right(())
               } else {
-                Left(Json.obj("error" -> s"Elasticsearch index creation error: ${createResp.status}", "body" -> createResp.body))
+                Left(Json.obj("error" -> s"Elasticsearch index creation error: ${createResp.status}", "body" -> (createResp.body: String)))
               }
             }
         }
       }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureIndex().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(_) =>
         env.Ws
           .url(s"$baseUrl/$index/_doc/${options.id}")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .put(Json.obj(
             "doc_id" -> options.id,
@@ -96,31 +97,31 @@ class ElasticsearchEmbeddingStoreClient(val config: JsObject, _storeId: String) 
             if (resp.status == 200 || resp.status == 201) {
               Right(())
             } else {
-              Left(Json.obj("error" -> s"Elasticsearch add error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"Elasticsearch add error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${options.id}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status == 200 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Elasticsearch delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Elasticsearch delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     env.Ws
       .url(s"$baseUrl/$index/_search")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "size" -> options.maxResults,
@@ -148,7 +149,7 @@ class ElasticsearchEmbeddingStoreClient(val config: JsObject, _storeId: String) 
           }
           Right(EmbeddingSearchResponse(matches))
         } else {
-          Left(Json.obj("error" -> s"Elasticsearch search error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Elasticsearch search error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elasticsearch_persistentmemory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elasticsearch_persistentmemory.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object ElasticsearchPersistentMemoryClient {
   lazy val logger = Logger("ElasticsearchPersistentMemoryClient")
@@ -40,10 +41,10 @@ class ElasticsearchPersistentMemoryClient(val config: JsObject, _memoryId: Strin
 
   private def docId(sessionId: String): String = s"${_memoryId}_${sessionId}"
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .put(Json.obj(
         "memory_id" -> _memoryId,
@@ -54,15 +55,15 @@ class ElasticsearchPersistentMemoryClient(val config: JsObject, _memoryId: Strin
         if (resp.status == 200 || resp.status == 201) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Elasticsearch update error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Elasticsearch update error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .map { resp =>
@@ -73,22 +74,22 @@ class ElasticsearchPersistentMemoryClient(val config: JsObject, _memoryId: Strin
         } else if (resp.status == 404) {
           Right(Seq.empty[PersistedChatMessage])
         } else {
-          Left(Json.obj("error" -> s"Elasticsearch get error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Elasticsearch get error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status == 200 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Elasticsearch delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Elasticsearch delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elevenlabs.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/elevenlabs.scala
@@ -1,17 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.{AudioGenVoice, AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioModelClientTranslationInputOptions, AudioTranscriptionResponse, AudioTranscriptionResponseMetadata}
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpEntity, Multipart}
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.{AudioGenVoice, AudioModelClient, AudioModelClientSpeechToTextInputOptions, AudioModelClientTextToSpeechInputOptions, AudioTranscriptionResponse, AudioTranscriptionResponseMetadata}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 
 object ElevenLabsModels {
   val DEFAULT = "eleven_monolingual_v1"
@@ -24,9 +25,9 @@ object ElevenLabsApi {
 }
 
 class ElevenLabsApi(baseUrl: String = ElevenLabsApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("ElevenLabs", method, url, body)(env)
+    ProviderHelpers.logCall("ElevenLabs", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -41,10 +42,10 @@ class ElevenLabsApi(baseUrl: String = ElevenLabsApi.baseUrl, token: String, time
       .withRequestTimeout(timeout)
       .execute()
   }
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("ElevenLabs", method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall("ElevenLabs", method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -86,7 +87,7 @@ class ElevenLabsAudioModelClient(val api: ElevenLabsApi, val ttsOptions: ElevenL
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = false
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     api.rawCall("GET", "/v2/voices?include_total_count=true", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("voices").as[List[JsObject]].map(obj => AudioGenVoice(obj.select("voice_id").asString, obj.select("name").asString))
@@ -97,7 +98,7 @@ class ElevenLabsAudioModelClient(val api: ElevenLabsApi, val ttsOptions: ElevenL
     }
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val finalModel: String = opts.model.getOrElse(ttsOptions.model)
     val finalVoice: String = opts.voice.getOrElse(ttsOptions.voice)
     val finalFormat: String = opts.responseFormat.getOrElse(ttsOptions.format)
@@ -117,7 +118,7 @@ class ElevenLabsAudioModelClient(val api: ElevenLabsApi, val ttsOptions: ElevenL
     }
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model).getOrElse("scribe_v1")
     val language = opts.language.orElse(sttOptions.language)
     val parts = List(
@@ -136,7 +137,7 @@ class ElevenLabsAudioModelClient(val api: ElevenLabsApi, val ttsOptions: ElevenL
         HttpEntity(language.byteString),
       )
     }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/v1/speech-to-text", form).map { response =>
       if (response.status == 200) {
         AudioTranscriptionResponse(response.json.select("text").asString, AudioTranscriptionResponseMetadata.empty).right

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/gemini.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/gemini.scala
@@ -1,5 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
+
 object GeminiApi {
   def baseUrl: String = "https://generativelanguage.googleapis.com/v1beta/openai"
   def url(model: String, token: String): String = {
@@ -30,7 +31,7 @@ class GeminiApi(val model: String, token: String, timeout: FiniteDuration = 10.s
 
   override def supportsTools: Boolean = false
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = GeminiApi.genericUrl(path, token)
     ProviderHelpers.logCall("Gemini", method, url, body)(env)
     env.Ws
@@ -47,7 +48,7 @@ class GeminiApi(val model: String, token: String, timeout: FiniteDuration = 10.s
       .execute()
   }
 
-  def call(method: String, patkh: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[Either[JsValue, GeminiApiResponse]] = {
+  def call(method: String, patkh: String, body: Option[JsValue])(using ec: ExecutionContext): Future[Either[JsValue, GeminiApiResponse]] = {
     val finalModel = Option(patkh).filter(_.nonEmpty).getOrElse(model)
     val url = s"${GeminiApi.url(finalModel, token)}"
     ProviderHelpers.logCall("Gemini", method, url, body)(env)
@@ -64,7 +65,7 @@ class GeminiApi(val model: String, token: String, timeout: FiniteDuration = 10.s
       .withRequestTimeout(timeout)
       .execute()
       .map(r => ProviderHelpers.wrapResponse("Gemini", r, env) { resp =>
-        GeminiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        GeminiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
@@ -122,7 +123,7 @@ class GeminiChatClient(api: GeminiApi, options: GeminiChatClientOptions, id: Str
 
   override def model: Option[String] = api.model.some
 
-  override def listModels()(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels()(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("models").as[List[JsObject]].map(obj => obj.select("name").asString.replaceFirst("models/", "")))
@@ -132,7 +133,7 @@ class GeminiChatClient(api: GeminiApi, options: GeminiChatClientOptions, id: Str
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider" - "model"
     val bodyOpts = obody.select("generationConfig").asOpt[JsObject].getOrElse(Json.obj())
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(bodyOpts) else options.jsonForCall

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/groq.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/groq.scala
@@ -1,17 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpEntity, Multipart}
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import java.io.{File, FileOutputStream}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -39,9 +39,9 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
   val supportsStreaming: Boolean = true
   override def supportsCompletion: Boolean = false
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Groq", method, url, body)(env)
+    ProviderHelpers.logCall("Groq", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -57,10 +57,10 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
       .execute()
   }
 
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Groq", method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall("Groq", method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -75,9 +75,9 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
   }
 
   /** raw streamed POST, used by the native /responses path */
-  def rawStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("Groq", method, url, body)(env)
+    ProviderHelpers.logStream("Groq", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -93,15 +93,15 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
       .stream()
   }
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, GroqApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, GroqApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("Groq", r, env) { resp =>
         acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-        GroqApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        GroqApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, GroqApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, GroqApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -115,7 +115,7 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) // .map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "groq", attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "groq", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -132,9 +132,9 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
     }
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("Groq", method, url, body)(env)
+    ProviderHelpers.logStream("Groq", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -169,7 +169,7 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
       })
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -182,12 +182,11 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
           var isToolCallEnded = false
           var toolCalls: Seq[OpenAiChatResponseChunkChoiceDeltaToolCall] = Seq.empty
           var toolCallArgs: scala.collection.mutable.ArraySeq[String] = scala.collection.mutable.ArraySeq.empty
-          var toolCallUsage: OpenAiChatResponseChunkUsage = null
           val newSource = res._1.flatMapConcat { chunk =>
             if (!isToolCall && chunk.choices.exists(_.delta.exists(_.tool_calls.nonEmpty))) {
               isToolCall = true
               toolCalls = chunk.choices.head.delta.head.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.finish_reason.contains("tool_calls")) {
@@ -206,12 +205,11 @@ class GroqApi(baseUrl: String = GroqApi.baseUrl, token: String, timeout: FiniteD
                 }}
               Source.empty
             } else if (isToolCall && isToolCallEnded) {
-              toolCallUsage = chunk.usage.get
               val calls = toolCalls.zipWithIndex.map {
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "groq", attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "groq", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -334,10 +332,10 @@ class GroqChatClient(api: GroqApi, options: GroqChatClientOptions, id: String) e
     mcpExcludeFunctions = options.mcpExcludeFunctions,
     maxFunctionCalls = options.maxFunctionCalls,
   )
-  override protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/openai/v1/responses", body.some)
-  override protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/openai/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
+  override protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/openai/v1/responses", body.some)
+  override protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/openai/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/openai/v1/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -347,7 +345,7 @@ class GroqChatClient(api: GroqApi, options: GroqChatClientOptions, id: String) e
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -393,7 +391,6 @@ class GroqChatClient(api: GroqApi, options: GroqChatClientOptions, id: String) e
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -405,7 +402,7 @@ class GroqChatClient(api: GroqApi, options: GroqChatClientOptions, id: String) e
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -454,7 +451,6 @@ class GroqChatClient(api: GroqApi, options: GroqChatClientOptions, id: String) e
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
               true
@@ -543,7 +539,7 @@ class GroqAudioModelClient(val api: GroqApi, val ttsOptions: GroqAudioModelClien
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = translationOptions.enabled
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     Right(
       List(
         AudioGenVoice("Arista-PlayAI", "Arista-PlayAI"),
@@ -553,7 +549,7 @@ class GroqAudioModelClient(val api: GroqApi, val ttsOptions: GroqAudioModelClien
     ).vfuture
   }
 
-  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val prompt = opts.prompt.orElse(sttOptions.prompt)
     val responseFormat = opts.responseFormat.orElse(sttOptions.responseFormat)
@@ -588,18 +584,18 @@ class GroqAudioModelClient(val api: GroqApi, val ttsOptions: GroqAudioModelClien
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/openai/v1/audio/translations", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
     }
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val language = opts.language.orElse(sttOptions.language)
     val prompt = opts.prompt.orElse(sttOptions.prompt)
@@ -640,18 +636,18 @@ class GroqAudioModelClient(val api: GroqApi, val ttsOptions: GroqAudioModelClien
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/openai/v1/audio/transcriptions", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
     }
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val instructionsOpt: Option[String] = opts.instructions.orElse(ttsOptions.instructions)
     val responseFormatOpt: Option[String] = opts.responseFormat.orElse(ttsOptions.responseFormat)
     val speedOpt: Option[Double] = opts.speed.orElse(ttsOptions.speed)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/hive.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/hive.scala
@@ -1,11 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,9 +18,9 @@ object HiveApi {
 
 class HiveApi(baseUrl: String = HiveApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Hive", method, url, body)(env)
+    ProviderHelpers.logCall("Hive", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -64,7 +65,7 @@ class HiveImageModelClient(val api: HiveApi, val genOptions: HiveImageModelClien
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = false
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse("black-forest-labs/flux-schnell")
     val body = Json.obj(
         "prompt" -> opts.prompt,
@@ -81,7 +82,7 @@ class HiveImageModelClient(val api: HiveApi, val genOptions: HiveImageModelClien
 
     api.rawCall("POST", s"/${finalModel}", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created_at").asOpt[Long].getOrElse(-1L),
           images = resp.json.select("output").as[Seq[JsObject]].map(o => ImagesGen(None, None, o.select("url").asOpt[String])),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/http_persistentmemory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/http_persistentmemory.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 // Generic HTTP backend for persistent memory
 // The remote API is expected to support:
@@ -38,10 +39,10 @@ class HttpPersistentMemoryClient(val config: JsObject, _memoryId: String) extend
 
   private def sessionUrl(sessionId: String): String = s"$baseUrl/${_memoryId}/$sessionId"
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(sessionUrl(sessionId))
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .put(Json.obj(
         "messages" -> JsArray(messages.map(_.raw))
@@ -50,15 +51,15 @@ class HttpPersistentMemoryClient(val config: JsObject, _memoryId: String) extend
         if (resp.status >= 200 && resp.status < 300) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"HTTP memory update error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"HTTP memory update error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     env.Ws
       .url(sessionUrl(sessionId))
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .map { resp =>
@@ -68,22 +69,22 @@ class HttpPersistentMemoryClient(val config: JsObject, _memoryId: String) extend
         } else if (resp.status == 404) {
           Right(Seq.empty[PersistedChatMessage])
         } else {
-          Left(Json.obj("error" -> s"HTTP memory get error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"HTTP memory get error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(sessionUrl(sessionId))
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status >= 200 && resp.status < 300 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"HTTP memory delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"HTTP memory delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/huggingface.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/huggingface.scala
@@ -1,13 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
-import otoroshi.env.Env
-import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json.{JsObject, JsValue, Json}
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
-import scala.concurrent.{ExecutionContext, Future}
 
 /*
 case class HuggingfaceApiResponse(status: Int, headers: Map[String, String], body: JsValue) {
@@ -35,7 +29,7 @@ class HuggingfaceApi(val modelName: String, token: String, timeout: FiniteDurati
 
   override def supportsCompletion: Boolean = false
 
-  def call(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[Either[JsValue, HuggingfaceApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[Either[JsValue, HuggingfaceApiResponse]] = {
     val url = s"${HuggingfaceApi.url(modelName)}${path}"
     ProviderHelpers.logCall("Huggingface", method, url, body)(env)
     env.Ws
@@ -52,7 +46,7 @@ class HuggingfaceApi(val modelName: String, token: String, timeout: FiniteDurati
       .withRequestTimeout(timeout)
       .execute()
       .map(r => ProviderHelpers.wrapResponse("Huggingface", r, env) { resp =>
-        HuggingfaceApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        HuggingfaceApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 }
@@ -109,7 +103,7 @@ class HuggingfaceChatClient(api: HuggingfaceApi, options: HuggingfaceChatClientO
 
   override def model: Option[String] = api.modelName.some
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     api.call("POST", "/chat/completions", Some(mergedOptions ++ Json.obj("messages" -> prompt.jsonWithFlavor(ChatMessageContentFlavor.OpenAi)))).map {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/jlama.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/jlama.scala
@@ -1,11 +1,11 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.Source
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.Source
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
 import play.api.libs.json.{JsObject, JsValue, Json}
 import reactor.core.publisher.Sinks
@@ -41,7 +41,7 @@ class JlamaChatClient(options: JlamaChatClientOptions, id: String) extends ChatC
   lazy val canExecuteJlama: Boolean = JlamaChatClient.canExecuteJlama
   lazy val errorMsg: String = JlamaChatClient.errorMsg
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     if (canExecuteJlama) {
       JlamaChatClient.models.keys.toList.rightf
     } else {
@@ -59,7 +59,7 @@ class JlamaChatClient(options: JlamaChatClientOptions, id: String) extends ChatC
     JlamaChatClientOptions(opts)
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     if (canExecuteJlama) {
       JlamaChatClient.generate(prompt, attrs, computeOptions(originalBody), id)
     } else {
@@ -67,7 +67,7 @@ class JlamaChatClient(options: JlamaChatClientOptions, id: String) extends ChatC
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (canExecuteJlama) {
       JlamaChatClient.stream(prompt, attrs, computeOptions(originalBody), id).future
     } else {
@@ -75,7 +75,7 @@ class JlamaChatClient(options: JlamaChatClientOptions, id: String) extends ChatC
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     if (canExecuteJlama) {
       JlamaChatClient.generate(prompt, attrs, computeOptions(originalBody), id)
     } else {
@@ -83,7 +83,7 @@ class JlamaChatClient(options: JlamaChatClientOptions, id: String) extends ChatC
     }
   }
 
-  override def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def completionStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (canExecuteJlama) {
       JlamaChatClient.stream(prompt, attrs, computeOptions(originalBody), id).future
     } else {
@@ -219,7 +219,6 @@ object JlamaChatClient {
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         ChatResponse(
@@ -242,10 +241,10 @@ object JlamaChatClient {
       } catch {
         case e: Throwable => Left(Json.obj("error" -> e.getMessage))
       }
-    }(ecccc)
+    }(using ecccc)
   }
 
-  def stream(prompt: ChatPrompt, attrs: TypedMap, options: JlamaChatClientOptions, id: String): Either[JsValue, Source[ChatResponseChunk, _]] = {
+  def stream(prompt: ChatPrompt, attrs: TypedMap, options: JlamaChatClientOptions, id: String): Either[JsValue, Source[ChatResponseChunk, ?]] = {
     val hotSource = Sinks.many().unicast().onBackpressureBuffer[ChatResponseChunk]()
     val hotFlux   = hotSource.asFlux()
       try {
@@ -302,11 +301,10 @@ object JlamaChatClient {
               val newArr = arr ++ Seq(slug)
               obj ++ Json.obj("ai" -> newArr)
             }
-            case Some(other) => other
             case None => Json.obj("ai" -> Seq(slug))
           }
           hotSource.tryEmitComplete()
-        }(ecccc)
+        }(using ecccc)
       } catch {
         case t: Throwable => {
           hotSource.tryEmitError(t)

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/leonardoai.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/leonardoai.scala
@@ -1,11 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,9 +18,9 @@ object LeonardoAIApi {
 
 class LeonardoAIApi(baseUrl: String = LeonardoAIApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("LeonardoAI", method, url, body)(env)
+    ProviderHelpers.logCall("LeonardoAI", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -60,7 +61,7 @@ class LeonardoAIImageModelClient(val api: LeonardoAIApi, val genOptions: Leonard
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = false
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse("6b645e3a-d64f-4341-a6d8-7a3690fbf042")
     val body = Json.obj(
       "prompt" -> opts.prompt,
@@ -73,7 +74,7 @@ class LeonardoAIImageModelClient(val api: LeonardoAIApi, val genOptions: Leonard
 
     api.rawCall("POST", s"/generations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = System.currentTimeMillis(),
           images = Seq(ImagesGen(None, None, resp.json.select("sdGenerationJob").select("generationId").asOpt[String].map(id => s"https://cloud.leonardo.ai/api/rest/v1/generations/${id}"))),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/local.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/local.scala
@@ -1,18 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.alpakka.s3.scaladsl.S3
-import akka.stream.alpakka.s3._
-import akka.stream.scaladsl.Sink
-import akka.stream.{Attributes, Materializer}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.connectors.s3.scaladsl.S3
+import org.apache.pekko.stream.connectors.s3.*
+import org.apache.pekko.stream.scaladsl.{Keep, Sink}
+import org.apache.pekko.stream.{Attributes, Materializer}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import dev.langchain4j.data.segment.TextSegment
 import otoroshi.env.Env
 import otoroshi.storage.drivers.inmemory.S3Configuration
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.regions.providers.AwsRegionProvider
@@ -23,18 +23,18 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class AllMiniLmL6V2EmbeddingModelClient(val options: JsObject, id: String) extends EmbeddingModelClient {
 
   lazy val embeddingModel = new dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel()
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
-    val r = embeddingModel.embedAll(seqAsJavaList(opts.input.map(s => TextSegment.from(s))))
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+    val r = embeddingModel.embedAll(opts.input.map(s => TextSegment.from(s)).asJava)
     try {
       Right(EmbeddingResponse(
         model = "all-minilm-l6-v2",
-        embeddings = r.content().asScala.map(e => Embedding(e.vector())),
+        embeddings = r.content().asScala.toSeq.map(e => Embedding(e.vector())),
         metadata = EmbeddingResponseMetadata(-1L),
       )).vfuture
     } catch {
@@ -53,7 +53,7 @@ class LocalEmbeddingStoreClient(val config: JsObject, _storeId: String) extends 
   private lazy val connection: JsObject = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
   private lazy val _sessionId: Option[String] = connection.select("session_id").asOptString
 
-  private def getStore()(implicit ec: ExecutionContext, env: Env): Future[dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore[TextSegment]] = {
+  private def getStore()(using ec: ExecutionContext, env: Env): Future[dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore[TextSegment]] = {
     val id = _sessionId match {
       case Some(sessionId) => s"${_storeId}:${sessionId}"
       case None => _storeId
@@ -78,7 +78,7 @@ class LocalEmbeddingStoreClient(val config: JsObject, _storeId: String) extends 
     }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getStore().map { store =>
       val lcEmbedding = new dev.langchain4j.data.embedding.Embedding(options.embedding.vector)
       store.add(options.id, lcEmbedding, TextSegment.from(options.input))
@@ -86,14 +86,14 @@ class LocalEmbeddingStoreClient(val config: JsObject, _storeId: String) extends 
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getStore().map { store =>
       store.remove(options.id)
       ().right
     }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     getStore().flatMap { store =>
       try {
         val lcEmbedding = new dev.langchain4j.data.embedding.Embedding(options.embedding.vector)
@@ -135,42 +135,39 @@ class LocalEmbeddingStoreClient(val config: JsObject, _storeId: String) extends 
     S3Attributes.settings(settings)
   }
 
-  private def fileContent(key: String, config: S3Configuration)(implicit
+  private def fileContent(key: String, config: S3Configuration)(using
                                                                 ec: ExecutionContext,
                                                                 mat: Materializer
   ): Future[Option[(ObjectMetadata, ByteString)]] = {
-    S3.download(config.bucket, key)
+    // S3.download is deprecated in pekko-connectors: getObject streams the bytes and
+    // materializes the metadata, and signals a missing object with a NoSuchKey S3Exception
+    // instead of an empty Option
+    val (metadataF, contentF) = S3
+      .getObject(config.bucket, key)
       .withAttributes(s3ClientSettingsAttrs(config))
-      .runWith(Sink.headOption)
-      .map(_.flatten)
-      .flatMap { opt =>
-        opt
-          .map {
-            case (source, om) => {
-              source.runFold(ByteString.empty)(_ ++ _).map { content =>
-                (om, content).some
-              }
-            }
-          }
-          .getOrElse(None.vfuture)
-      }
+      .toMat(Sink.fold(ByteString.empty)(_ ++ _))(Keep.both)
+      .run()
+    metadataF
+      .zip(contentF)
+      .map(_.some)
+      .recover { case e: S3Exception if e.code == "NoSuchKey" => None }
   }
 
-  private def getDefaultCode()(implicit env: Env, ec: ExecutionContext): Future[String] = {
+  private def getDefaultCode()(using env: Env, ec: ExecutionContext): Future[String] = {
     """{"entries":[]}""".vfuture
   }
 
-  private def getInitialStoreContent(path: String, headers: Map[String, String])(implicit env: Env, ec: ExecutionContext): Future[String] = {
+  private def getInitialStoreContent(path: String, headers: Map[String, String])(using env: Env, ec: ExecutionContext): Future[String] = {
     import LocalEmbeddingStoreClient.logger
     if (path.startsWith("https://") || path.startsWith("http://")) {
       env.Ws.url(path)
         .withFollowRedirects(true)
         .withRequestTimeout(30.seconds)
-        .withHttpHeaders(headers.toSeq: _*)
+        .withHttpHeaders(headers.toSeq*)
         .get()
         .flatMap { response =>
           if (response.status == 200) {
-            response.body.vfuture
+            (response.body: String).vfuture
           } else {
             getDefaultCode()
           }
@@ -185,8 +182,8 @@ class LocalEmbeddingStoreClient(val config: JsObject, _storeId: String) extends 
       }
     } else if (path.startsWith("s3://")) {
       logger.info(s"fetching from S3: ${path}")
-      val config = S3Configuration.format.reads(JsObject(headers.mapValues(_.json))).get
-      fileContent(path.replaceFirst("s3://", ""), config)(env.otoroshiExecutionContext, env.otoroshiMaterializer).flatMap {
+      val config = S3Configuration.format.reads(JsObject(headers.view.mapValues(_.json).toMap)).get
+      fileContent(path.replaceFirst("s3://", ""), config)(using env.otoroshiExecutionContext, env.otoroshiMaterializer).flatMap {
         case None => {
           logger.info(s"unable to fetch from S3: ${path}")
           getDefaultCode()
@@ -220,21 +217,21 @@ object LocalPersistentMemoryClient {
 
 class LocalPersistentMemoryClient(val config: JsObject, id: String) extends PersistentMemoryClient {
 
-  private def getMemory(sessionId: String)(implicit env: Env, ec: ExecutionContext): LocalPersistentMemoryClientMemory = {
+  private def getMemory(sessionId: String)(using env: Env, ec: ExecutionContext): LocalPersistentMemoryClientMemory = {
     val memories = LocalPersistentMemoryClient.memories.getOrElseUpdate(id, new TrieMap[String, LocalPersistentMemoryClientMemory]())
     memories.getOrElseUpdate(sessionId, LocalPersistentMemoryClientMemory(sessionId))
   }
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getMemory(sessionId).updateMessages(messages)
     ().rightf
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     getMemory(sessionId).getMessages().rightf
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     getMemory(sessionId).clearMessages().rightf
   }
 }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/luma.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/luma.scala
@@ -1,11 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,9 +18,9 @@ object LumaApi {
 
 class LumaApi(baseUrl: String = LumaApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Luma", method, url, body)(env)
+    ProviderHelpers.logCall("Luma", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -57,7 +58,7 @@ class LumaImageModelClient(val api: LumaApi, val genOptions: LumaImageModelClien
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = false
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse("photon-1")
     val body = Json.obj(
       "prompt" -> opts.prompt,
@@ -66,7 +67,7 @@ class LumaImageModelClient(val api: LumaApi, val genOptions: LumaImageModelClien
     api.rawCall("POST", "/dream-machine/v1/generations/image", body.some).map { resp =>
       if (resp.status == 200) {
         val imageUrl = resp.json.at("assets.image").asOptString
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created_at").asOpt[Long].getOrElse(-1L),
           images = Seq(ImagesGen(None, None, imageUrl)),
@@ -114,7 +115,7 @@ class LumaVideoModelClient(val api: LumaApi, val genOptions: LumaVideoModelClien
 
   override def supportsTextToVideo: Boolean = genOptions.enabled
 
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse("photon-1")
     val body = Json.obj(
       "prompt" -> opts.prompt,
@@ -128,7 +129,7 @@ class LumaVideoModelClient(val api: LumaApi, val genOptions: LumaVideoModelClien
     api.rawCall("POST", "/dream-machine/v1/generations", body.some).map { resp =>
       if (resp.status == 200) {
         val imageUrl = resp.json.at("assets.video").asOptString
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(VideosGenResponse(
           created = resp.json.select("created_at").asOpt[Long].getOrElse(-1L),
           videos = Seq(VideosGen(None, None, imageUrl)),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/mistral.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/mistral.scala
@@ -1,18 +1,19 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 
 
 case class MistralAiApiResponse(status: Int, headers: Map[String, String], body: JsValue) {
@@ -53,9 +54,9 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
     }
   }
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Mistral", method, url, body)(env)
+    ProviderHelpers.logCall("Mistral", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -71,11 +72,11 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
       .execute()
   }
 
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
     val uri = Uri(url)
-    ProviderHelpers.logCall("Mistral", method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall("Mistral", method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -90,15 +91,15 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
       .execute()
   }
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, MistralAiApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, MistralAiApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("Mistral", r, env) { resp =>
         acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-        MistralAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+        MistralAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
       })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, MistralAiApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, MistralAiApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -112,7 +113,7 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) //.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "mistral", attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "mistral", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -130,9 +131,9 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
   }
 
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("Mistral", method, url, body)(env)
+    ProviderHelpers.logStream("Mistral", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -168,7 +169,7 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
       })
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -181,12 +182,11 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
           var isToolCallEnded = false
           var toolCalls: Seq[OpenAiChatResponseChunkChoiceDeltaToolCall] = Seq.empty
           var toolCallArgs: scala.collection.mutable.ArraySeq[String] = scala.collection.mutable.ArraySeq.empty
-          var toolCallUsage: OpenAiChatResponseChunkUsage = null
           val newSource = res._1.flatMapConcat { chunk =>
             if (!isToolCall && chunk.choices.exists(_.delta.exists(_.tool_calls.nonEmpty))) {
               isToolCall = true
               toolCalls = chunk.choices.head.delta.head.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.finish_reason.contains("tool_calls")) {
@@ -205,12 +205,11 @@ class MistralAiApi(_baseUrl: String = MistralAiApi.baseUrl, token: String, timeo
                 }}
               Source.empty
             } else if (isToolCall && isToolCallEnded) {
-              toolCallUsage = chunk.usage.get
               val calls = toolCalls.zipWithIndex.map {
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "mistral", attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "mistral", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -377,7 +376,6 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(options.model.some)
 
   override def transformOpenAIInputBodyToProviderInputBody(inputBody: JsObject): JsObject = {
-    val model = inputBody.select("model").asOptString.orElse(computeModel(inputBody)).getOrElse("--")
     val maxCompletionTokens = inputBody.select("max_completion_tokens").asOptLong
     //val reasoningEffort = inputBody.select("reasoning_effort").asOptString
     (inputBody - "max_completion_tokens")// - "reasoning_effort")
@@ -392,7 +390,7 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
       // }
   }
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -402,7 +400,7 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -449,7 +447,6 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -465,11 +462,10 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
-    val startTime = System.currentTimeMillis()
     val acc = new UsageAccumulator()
     val hasToolsInRequest = obody.select("tools").asOpt[JsArray].exists(_.value.nonEmpty)
     val callF = if (!hasToolsInRequest && api.supportsTools && (options.wasmTools.nonEmpty || options.mcpConnectors.nonEmpty || options.a2aConnectors.nonEmpty)) {
@@ -515,7 +511,6 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
               val hasToolCalls = chunk.choices.exists(_.finish_reason.contains("tool_calls"))
@@ -547,7 +542,7 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider" - "prompt"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -586,7 +581,6 @@ class MistralAiChatClient(api: MistralAiApi, options: MistralAiChatClientOptions
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -610,7 +604,7 @@ object MistralAiEmbeddingModelClientOptions {
 
 class MistralAiEmbeddingModelClient(val api: MistralAiApi, val options: MistralAiEmbeddingModelClientOptions, id: String) extends EmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     api.rawCall("POST", "/embeddings", (options.raw ++ Json.obj("input" -> opts.input, "model" -> finalModel)).some).map { resp =>
       if (resp.status == 200) {
@@ -642,7 +636,7 @@ object MistralAiModerationModelClientOptions {
 
 class MistralAiModerationModelClient(val api: MistralAiApi, val options: MistralAiModerationModelClientOptions, id: String) extends ModerationModelClient {
 
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     val body = Json.obj(
       "input" -> JsArray(opts.input.filter(_.isText).map(_.mistralJson)),
@@ -650,7 +644,7 @@ class MistralAiModerationModelClient(val api: MistralAiApi, val options: Mistral
     )
     api.rawCall("POST", "/moderations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ModerationResponse(
           model = resp.json.select("model").asString,
           moderationResults = resp.json.select("results").as[Seq[JsObject]].map(o => ModerationResult(
@@ -697,7 +691,7 @@ class MistralAIAudioModelClient(val api: MistralAiApi, val sttOptions: MistralAi
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = false
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
     Right(
       List(
         AudioGenModel("voxtral-mini-latest", "voxtral-mini-latest"),
@@ -706,11 +700,11 @@ class MistralAIAudioModelClient(val api: MistralAiApi, val sttOptions: MistralAi
     ).vfuture
   }
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     List.empty.rightf
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val language = opts.language.orElse(sttOptions.language)
     val diarize = rawBody.select("diarize").asOptBoolean.orElse(sttOptions.diarize)
@@ -744,11 +738,11 @@ class MistralAIAudioModelClient(val api: MistralAiApi, val sttOptions: MistralAi
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/audio/transcriptions", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
@@ -770,14 +764,14 @@ object MistralOcrModelClientOptions {
 
 class MistralOcrModelClient(val api: MistralAiApi, val options: MistralOcrModelClientOptions, id: String) extends OcrModelClient {
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[OcrGenModel]]] = {
     Right(List(
       OcrGenModel("mistral-ocr-latest", "mistral-ocr-latest"),
       OcrGenModel("mistral-ocr-2505", "mistral-ocr-2505"),
     )).vfuture
   }
 
-  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
+  override def ocr(opts: OcrModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, OcrModelClientResponse]] = {
     val model = opts.model.getOrElse(options.model)
     // Build the Mistral document reference: a remote url, or an inline base64 data-uri.
     val documentOpt: Option[JsObject] = opts.url match {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/nativeresponses.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/nativeresponses.scala
@@ -1,14 +1,14 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{A2ASupport, GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
 
 import java.util.concurrent.atomic.AtomicReference
@@ -59,9 +59,9 @@ trait NativeResponsesSupport extends ChatClient {
   /** parameters the provider documents as unsupported on its `/responses` endpoint */
   protected def responsesUnsupportedParams: Seq[String] = Seq.empty
   /** POST the payload to the provider's `/responses` endpoint */
-  protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse]
+  protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse]
   /** same, as a stream of `text/event-stream` bytes */
-  protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse]
+  protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse]
 
   override def supportsResponses: Boolean = responsesEnabled
 
@@ -70,7 +70,7 @@ trait NativeResponsesSupport extends ChatClient {
   // the payload to POST, the model it targets, and whether the gateway injected its own tools —
   // only then does it execute the tool calls itself. Tools declared by the caller are its own
   // business: their calls are returned to it, exactly like on the chat/completions path.
-  private def payload(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): (JsObject, String, Boolean) = {
+  private def payload(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): (JsObject, String, Boolean) = {
     val body = originalBody.asObject - "messages" - "provider" - "input" - "instructions"
     val merged = if (responsesAllowConfigOverride) responsesChatOptions.deepMerge(body) else responsesChatOptions
     val params = responsesUnsupportedParams.foldLeft(OpenAiResponsesBodyConverter.toResponsesBody(merged))(_ - _)
@@ -107,7 +107,6 @@ trait NativeResponsesSupport extends ChatClient {
         val arr = obj.select("ai").asOpt[Seq[JsObject]].getOrElse(Seq.empty)
         obj ++ Json.obj("ai" -> (arr ++ Seq(slug)))
       }
-      case Some(other) => other
       case None => Json.obj("ai" -> Seq(slug))
     }
   }
@@ -127,17 +126,17 @@ trait NativeResponsesSupport extends ChatClient {
 
   // ---- blocking ---------------------------------------------------------------------------
 
-  private def rawJsonCall(body: JsObject, acc: UsageAccumulator)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (JsValue, Map[String, String])]] = {
+  private def rawJsonCall(body: JsObject, acc: UsageAccumulator)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (JsValue, Map[String, String])]] = {
     responsesRawCall(body).map(r => ProviderHelpers.wrapResponse(responsesProviderKind, r, env) { resp =>
       acc.updateOpenaiResponses(resp.json.select("usage").asOpt[JsObject])
-      (resp.json, resp.headers.mapValues(_.last))
+      (resp.json, resp.headers.view.mapValues(_.last).toMap)
     })
   }
 
   // Tool loop of the responses API: `function_call` output items are executed and appended back to
   // `input` as `function_call` + `function_call_output` items (the chat/completions loop appends
   // assistant/tool messages instead).
-  private def callWithToolSupport(body: JsObject, attrs: TypedMap, nameToFunction: Map[String, String], currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (JsValue, Map[String, String])]] = {
+  private def callWithToolSupport(body: JsObject, attrs: TypedMap, nameToFunction: Map[String, String], currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (JsValue, Map[String, String])]] = {
     if (currentCallCounter >= responsesToolsOptions.maxFunctionCalls) {
       return rawJsonCall(body, acc)
     }
@@ -159,7 +158,7 @@ trait NativeResponsesSupport extends ChatClient {
               "function" -> Json.obj("name" -> name, "arguments" -> arguments),
             ))
           }
-          LlmFunctions.callToolsOpenai(calls, responsesToolsOptions.mcpConnectors, responsesProviderKind, attrs, nameToFunction)(ec, env).flatMap { callResps =>
+          LlmFunctions.callToolsOpenai(calls, responsesToolsOptions.mcpConnectors, responsesProviderKind, attrs, nameToFunction)(using ec, env).flatMap { callResps =>
             val previousInput = body.select("input").asOpt[Seq[JsObject]].getOrElse(Seq.empty)
             // the tool results come back as chat messages, turn them into responses input items
             val resultItems = OpenAiResponsesBodyConverter.chatMessagesToInput(callResps.map(_.asObject)).value.map(_.asObject)
@@ -171,7 +170,7 @@ trait NativeResponsesSupport extends ChatClient {
     }
   }
 
-  final override def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  final override def response(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     if (!responsesEnabled) {
       return super.response(prompt, attrs, originalBody)
     }
@@ -198,7 +197,7 @@ trait NativeResponsesSupport extends ChatClient {
 
   // ---- streaming --------------------------------------------------------------------------
 
-  final override def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  final override def responseStream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     if (!responsesEnabled) {
       return super.responseStream(prompt, attrs, originalBody)
     }
@@ -218,7 +217,7 @@ trait NativeResponsesSupport extends ChatClient {
     })
   }
 
-  private def eventToChunks(event: JsValue, responseId: AtomicReference[String], finalModel: String, resp: WSResponse, acc: UsageAccumulator, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Source[ChatResponseChunk, _] = {
+  private def eventToChunks(event: JsValue, responseId: AtomicReference[String], finalModel: String, resp: WSResponse, acc: UsageAccumulator, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Source[ChatResponseChunk, ?] = {
     val typ = event.select("type").asOptString.getOrElse("")
     val created = System.currentTimeMillis() / 1000L
     def chunk(delta: ChatResponseChunkChoiceDelta, finishReason: Option[String] = None, usage: Option[ChatResponseMetadataUsage] = None): ChatResponseChunk = {
@@ -259,7 +258,7 @@ trait NativeResponsesSupport extends ChatClient {
       case "response.completed" => {
         // usage is only read here: `response.created` / `response.in_progress` carry "usage": null
         acc.updateOpenaiResponses(event.at("response.usage").asOpt[JsObject])
-        val usage = metadataFrom(resp.headers.mapValues(_.last), acc.usage())
+        val usage = metadataFrom(resp.headers.view.mapValues(_.last).toMap, acc.usage())
         registerUsage(usage, finalModel, resp.header("openai-processing-ms").map(_.toLong).getOrElse(0L), attrs)
         val hadToolCalls = event.at("response.output").asOpt[Seq[JsObject]].getOrElse(Seq.empty).exists(_.select("type").asOptString.contains("function_call"))
         Source.single(chunk(

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/ollama.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/ollama.scala
@@ -1,19 +1,20 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import org.joda.time.DateTime
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 
 case class OllamaAiApiResponseChoiceMessageToolCallFunction(raw: JsObject) {
   lazy val name: String = raw.select("name").asString
@@ -95,9 +96,9 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
   override def supportsStreaming: Boolean = true
   override def  supportsCompletion: Boolean = true
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Ollama", method, url, body)(env)
+    ProviderHelpers.logCall("Ollama", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -120,9 +121,9 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
   }
 
   /** raw streamed POST, used by the native /responses path */
-  def rawStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("Ollama", method, url, body)(env)
+    ProviderHelpers.logStream("Ollama", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -141,17 +142,17 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
       .stream()
   }
 
-  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OllamaAiApiResponse]] = {
+  def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OllamaAiApiResponse]] = {
     rawCall(method, path, body)
       .map(r => ProviderHelpers.wrapResponse("Ollama", r, env) { resp =>
         acc.updateOllama(resp.json.some)
-        OllamaAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json, resp)
+        OllamaAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json, resp)
       })
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OllamaAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OllamaAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("Ollama", method, url, body)(env)
+    ProviderHelpers.logStream("Ollama", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -187,7 +188,7 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
       })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OllamaAiApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OllamaAiApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -201,7 +202,7 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty)//.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOllama(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOllama(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -218,7 +219,7 @@ class OllamaAiApi(val baseUrl: String = OllamaAiApi.baseUrl, val token: Option[S
     }
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxFunctionCalls: Int, functionCalls: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OllamaAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxFunctionCalls: Int, functionCalls: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OllamaAiChatResponseChunk, ?], WSResponse)]] = {
     callWithToolSupport(method, path, body, mcpConnectors, attrs, nameToFunction, maxFunctionCalls, functionCalls, acc).map {case Left(err) => err.left
     case Right(resp) =>
       val source = resp.message.content.get.chunks(5).map { str =>
@@ -356,10 +357,10 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
     mcpExcludeFunctions = options.mcpExcludeFunctions,
     maxFunctionCalls = options.maxFunctionCalls,
   )
-  override protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/v1/responses", body.some)
-  override protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
+  override protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/v1/responses", body.some)
+  override protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/api/tags", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("models").as[List[JsObject]].map(obj => obj.select("name").asString))
@@ -369,7 +370,7 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall)
     val finalModel: String = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -426,7 +427,6 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val role = resp.body.select("message").select("role").asOpt[String].getOrElse("user")
@@ -436,7 +436,7 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val hasOtoTools = api.supportsTools && (options.wasmTools.nonEmpty || options.mcpConnectors.nonEmpty || options.a2aConnectors.nonEmpty || options.searchEngines.nonEmpty)
     val hasBodyTools = originalBody.select("tools").asOpt[JsArray].isDefined
     val startTime = System.currentTimeMillis()
@@ -490,7 +490,6 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
                     val newArr = arr ++ Seq(slug)
                     obj ++ Json.obj("ai" -> newArr)
                   }
-                  case Some(other) => other
                   case None => Json.obj("ai" -> Seq(slug))
                 }
                 true
@@ -521,7 +520,7 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider" - "prompt"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel: String = mergedOptions.select("model").asOptString.getOrElse(options.model)
@@ -562,7 +561,6 @@ class OllamaAiChatClient(api: OllamaAiApi, options: OllamaAiChatClientOptions, i
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -584,7 +582,7 @@ object OllamaEmbeddingModelClientOptions {
 
 class OllamaEmbeddingModelClient(val api: OllamaAiApi, val options: OllamaEmbeddingModelClientOptions, id: String) extends EmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     api.rawCall("POST", "/api/embed", (options.raw ++ Json.obj("input" -> opts.input)).some).map { resp =>
       if (resp.status == 200) {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openai.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openai.scala
@@ -1,18 +1,18 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpEntity, Multipart, Uri}
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{GenericApiResponseChoiceMessageToolCall, LlmFunctions}
 import io.azam.ulidj.ULID
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json.{JsArray, JsNull, JsObject, JsString, JsValue, Json}
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -190,17 +190,17 @@ class OpenAiApi(
     }
   }
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
     val uri = Uri(url)
-    ProviderHelpers.logCall(providerName, method, url, body)(env)
+    ProviderHelpers.logCall(providerName, method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
         resolvedHeaders ++ Seq(
           "Accept" -> "application/json",
           "Host" -> uri.authority.host.toString()
-        ): _*
+        )*
       ).applyOnWithOpt(applyParamMappings(body)) {
         case (builder, body) => builder
           .addHttpHeaders("Content-Type" -> "application/json")
@@ -216,18 +216,18 @@ class OpenAiApi(
       // }
   }
 
-  def rawCallForm(method: String, path: String, body: Multipart)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallForm(method: String, path: String, body: Multipart)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
     val uri = Uri(url)
-    ProviderHelpers.logCall(providerName, method, url, None)(env)
-    val entity = body.toEntity()
+    ProviderHelpers.logCall(providerName, method, url, None)(using env)
+    val entity = body.toEntity
     env.Ws
       .url(url)
       .withHttpHeaders(
         resolvedHeaders ++ Seq(
           "Accept" -> "application/json",
           "Host" -> uri.authority.host.toString(),
-          "Content-Type" -> entity.contentType.toString()): _*
+          "Content-Type" -> entity.contentType.toString())*
       )
       .withBody(entity.dataBytes)
       .withMethod(method)
@@ -240,14 +240,14 @@ class OpenAiApi(
       // }
   }
 
-  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
+  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
     rawCall(method, path, body).map(r => ProviderHelpers.wrapResponse(providerName, r, env) { resp =>
       acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-      OpenAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+      OpenAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
     })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
     // TODO: accumulate consumptions ???
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
@@ -261,7 +261,7 @@ class OpenAiApi(
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) //.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, providerName, attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, providerName, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -280,16 +280,16 @@ class OpenAiApi(
     }
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
     val uri = Uri(url)
-    ProviderHelpers.logStream(providerName, method, url, body)(env)
+    ProviderHelpers.logStream(providerName, method, url, body)(using env)
     env.Ws
       .url(s"${baseUrl}${path}")
       .withHttpHeaders(
         resolvedHeaders ++ Seq(
           "Accept" -> "application/json",
-          "Host" -> uri.authority.host.toString()): _*
+          "Host" -> uri.authority.host.toString())*
       ).applyOnWithOpt(applyParamMappings(body)) {
         case (builder, body) => builder
           .addHttpHeaders("Content-Type" -> "application/json")
@@ -320,16 +320,16 @@ class OpenAiApi(
   }
 
   /** raw streamed POST, used by the native /responses path */
-  def rawStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
     val uri = Uri(url)
-    ProviderHelpers.logStream(providerName, method, url, body)(env)
+    ProviderHelpers.logStream(providerName, method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
         resolvedHeaders ++ Seq(
           "Accept" -> "text/event-stream",
-          "Host" -> uri.authority.host.toString()): _*
+          "Host" -> uri.authority.host.toString())*
       ).applyOnWithOpt(applyParamMappings(body)) {
         case (builder, body) => builder
           .addHttpHeaders("Content-Type" -> "application/json")
@@ -340,7 +340,7 @@ class OpenAiApi(
       .stream()
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -360,12 +360,11 @@ class OpenAiApi(
           var isToolCallEnded = false
           var toolCalls: Seq[OpenAiChatResponseChunkChoiceDeltaToolCall] = Seq.empty
           var toolCallArgs: scala.collection.mutable.ArraySeq[String] = scala.collection.mutable.ArraySeq.empty
-          var toolCallUsage: OpenAiChatResponseChunkUsage = null
-          val newSource: Source[OpenAiChatResponseChunk, _]  = res._1.flatMapConcat { chunk =>
+          val newSource: Source[OpenAiChatResponseChunk, ?]  = res._1.flatMapConcat { chunk =>
             if (!isToolCall && chunk.choices.exists(_.delta.exists(_.tool_calls.nonEmpty))) {
               isToolCall = true
               toolCalls = chunk.choices.head.delta.head.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.finish_reason.contains("tool_calls")) {
@@ -384,12 +383,11 @@ class OpenAiApi(
                 }}
               Source.empty
             } else if (isToolCall && isToolCallEnded) {
-              toolCallUsage = chunk.usage.get
               val calls = toolCalls.zipWithIndex.map {
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, providerName, attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, providerName, attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps.map { resp =>
@@ -547,7 +545,7 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
   override def supportsStreaming: Boolean = api.supportsStreaming
   override def supportsCompletion: Boolean = completion //api.supportsCompletion
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val _mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel = _mergedOptions.select("model").asOptString.orElse(computeModel(_mergedOptions)).getOrElse("--")
@@ -565,7 +563,7 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
     callF.map {
       case Left(err) => err.left
       case Right((source, resp)) =>
-        source
+        (source: Source[OpenAiChatResponseChunk, Any])
           .applyOnIf(accumulateStreamConsumptions)(
             _.map { chunk =>
               if (chunk.choices.exists(_.finish_reason.contains("stop"))) {
@@ -598,7 +596,6 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
                     val newArr = arr ++ Seq(slug)
                     obj ++ Json.obj("ai" -> newArr)
                   }
-                  case Some(other) => other
                   case None => Json.obj("ai" -> Seq(slug))
                 }
               }
@@ -637,7 +634,6 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
                     val newArr = arr ++ Seq(slug)
                     obj ++ Json.obj("ai" -> newArr)
                   }
-                  case Some(other) => other
                   case None => Json.obj("ai" -> Seq(slug))
                 }
                 true
@@ -669,7 +665,7 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val _mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel = _mergedOptions.select("model").asOptString.orElse(computeModel(_mergedOptions)).getOrElse("--")
@@ -716,7 +712,6 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -728,7 +723,7 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
       }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider" - "prompt"
     val _mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel = _mergedOptions.select("model").asString
@@ -767,7 +762,6 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -778,7 +772,7 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
     }
   }
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", modelsPath, None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString)
@@ -810,8 +804,8 @@ class OpenAiChatClient(val api: OpenAiApi, val options: OpenAiChatClientOptions,
     mcpExcludeFunctions = options.mcpExcludeFunctions,
     maxFunctionCalls = options.maxFunctionCalls,
   )
-  override protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/responses", body.some)
-  override protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
+  override protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/responses", body.some)
+  override protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -828,7 +822,7 @@ object OpenAiEmbeddingModelClientOptions {
 
 class OpenAiEmbeddingModelClient(val api: OpenAiApi, val options: OpenAiEmbeddingModelClientOptions, id: String) extends EmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     api.rawCall("POST", "/embeddings", (options.raw ++ Json.obj("input" -> opts.input, "model" -> finalModel)).some).map { resp =>
       if (resp.status == 200) {
@@ -863,7 +857,7 @@ object OpenAiModerationModelClientOptions {
 
 class OpenAiModerationModelClient(val api: OpenAiApi, val options: OpenAiModerationModelClientOptions, id: String) extends ModerationModelClient {
 
-  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
+  override def moderate(opts: ModerationModelClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ModerationResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     val body = Json.obj(
       "input" -> JsArray(opts.input.map(_.openaiJson)),
@@ -871,7 +865,7 @@ class OpenAiModerationModelClient(val api: OpenAiApi, val options: OpenAiModerat
     )
     api.rawCall("POST", "/moderations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ModerationResponse(
           model = resp.json.select("model").asString,
           moderationResults = resp.json.select("results").as[Seq[JsObject]].map(o => ModerationResult(
@@ -943,7 +937,7 @@ class OpenAIAudioModelClient(val api: OpenAiApi, val ttsOptions: OpenAIAudioMode
   override def supportsStt: Boolean = sttOptions.enabled
   override def supportsTranslation: Boolean = translationOptions.enabled
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
     Right(
       List(
         AudioGenModel("tts-1", "tts-1"),
@@ -953,13 +947,13 @@ class OpenAIAudioModelClient(val api: OpenAiApi, val ttsOptions: OpenAIAudioMode
     ).vfuture
   }
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     List(
       "alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer", "verse"
     ).map(v => AudioGenVoice(v, v)).rightf
   }
 
-  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def translate(opts: AudioModelClientTranslationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val prompt = opts.prompt.orElse(sttOptions.prompt)
     val responseFormat = opts.responseFormat.orElse(sttOptions.responseFormat)
@@ -994,18 +988,18 @@ class OpenAIAudioModelClient(val api: OpenAiApi, val ttsOptions: OpenAIAudioMode
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/audio/translations", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
     }
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val instructionsOpt: Option[String] = opts.instructions.orElse(ttsOptions.instructions)
     val responseFormatOpt: Option[String] = opts.responseFormat.orElse(ttsOptions.responseFormat)
     val speedOpt: Option[Double] = opts.speed.orElse(ttsOptions.speed)
@@ -1032,7 +1026,7 @@ class OpenAIAudioModelClient(val api: OpenAiApi, val ttsOptions: OpenAIAudioMode
     }
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model)
     val language = opts.language.orElse(sttOptions.language)
     val prompt = opts.prompt.orElse(sttOptions.prompt)
@@ -1073,11 +1067,11 @@ class OpenAIAudioModelClient(val api: OpenAiApi, val ttsOptions: OpenAIAudioMode
           HttpEntity(temperature.toString.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/audio/transcriptions", form).map { response =>
       if (response.status == 200) {
         val body = response.json
-        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.mapValues(_.last))).right
+        AudioTranscriptionResponse(body.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(body.asObject, response.headers.view.mapValues(_.last).toMap)).right
       } else {
         Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
       }
@@ -1126,7 +1120,7 @@ class OpenAiImageModelClient(val api: OpenAiApi, val genOptions: OpenAiImageMode
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = editOptions.enabled
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel = opts.model.orElse(genOptions.model).getOrElse("gpt-image-1")
     val body = Json.obj(
         "prompt" -> opts.prompt,
@@ -1148,7 +1142,7 @@ class OpenAiImageModelClient(val api: OpenAiApi, val genOptions: OpenAiImageMode
 
     api.rawCall("POST", "/images/generations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created").asOpt[Long].getOrElse(-1L),
           images = resp.json.select("data").asOpt[Seq[JsObject]].map(_.map(o => ImagesGen(o.select("b64_json").asOpt[String], o.select("revised_prompt").asOpt[String], o.select("url").asOpt[String]))).getOrElse(Seq.empty),
@@ -1175,13 +1169,11 @@ class OpenAiImageModelClient(val api: OpenAiApi, val genOptions: OpenAiImageMode
   }
 
 
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel = opts.model.orElse(editOptions.model).getOrElse("gpt-image-1")
     val model = finalModel
     val background = opts.background.orElse(editOptions.background)
     val n = opts.n.orElse(editOptions.n)
-    val prompt = opts.prompt
-    val responseFormat = opts.responseFormat.orElse(editOptions.responseFormat)
     val quality = opts.quality.orElse(editOptions.quality)
     val size = opts.size.orElse(editOptions.size)
     val parts = opts.images.map(i => Multipart.FormData.BodyPart(
@@ -1223,10 +1215,10 @@ class OpenAiImageModelClient(val api: OpenAiApi, val genOptions: OpenAiImageMode
           HttpEntity(size.byteString),
         )
       }
-    val form = Multipart.FormData(parts: _*)
+    val form = Multipart.FormData(parts*)
     api.rawCallForm("POST", "/images/edits", form).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created").asOpt[Long].getOrElse(-1L),
           images = resp.json.select("data").as[Seq[JsObject]].map(o => ImagesGen(o.select("b64_json").asOpt[String], o.select("revised_prompt").asOpt[String], o.select("url").asOpt[String])),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openailike.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openailike.scala
@@ -1,6 +1,6 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsString, Json}
 
 

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openrouter.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/openrouter.scala
@@ -1,16 +1,17 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
-import scala.concurrent._
-import scala.concurrent.duration._
+import scala.concurrent.*
+import scala.concurrent.duration.*
 
 // OpenRouter - https://openrouter.ai/docs/api/api-reference
 // OpenRouter audio support is speech-to-text (STT, /audio/transcriptions) and text-to-speech
@@ -29,9 +30,9 @@ object OpenRouterApi {
 
 class OpenRouterApi(baseUrl: String = OpenRouterApi.baseUrl, token: String, timeout: FiniteDuration = 3.minutes, env: Env) {
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("OpenRouter", method, url, body)(env)
+    ProviderHelpers.logCall("OpenRouter", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -47,9 +48,9 @@ class OpenRouterApi(baseUrl: String = OpenRouterApi.baseUrl, token: String, time
       .execute()
   }
 
-  def rawCallStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCallStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("OpenRouter", method, url, body)(env)
+    ProviderHelpers.logCall("OpenRouter", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -126,19 +127,19 @@ class OpenRouterAudioModelClient(val api: OpenRouterApi, val ttsOptions: OpenRou
     case None => "audio/pcm"
   }
 
-  override def listModels(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
+  override def listModels(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenModel]]] = {
     Right(List(
       AudioGenModel(OpenRouterApi.defaultSttModel, OpenRouterApi.defaultSttModel),
       AudioGenModel(OpenRouterApi.defaultTtsModel, OpenRouterApi.defaultTtsModel),
     )).vfuture
   }
 
-  override def listVoices(raw: Boolean)(implicit ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
+  override def listVoices(raw: Boolean)(using ec: ExecutionContext): Future[Either[JsValue, List[AudioGenVoice]]] = {
     // OpenRouter voices are provider-specific (depend on the selected TTS model), no enumeration endpoint.
     List.empty.rightf
   }
 
-  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, _], String)]] = {
+  override def textToSpeech(opts: AudioModelClientTextToSpeechInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, (Source[ByteString, ?], String)]] = {
     val responseFormatOpt: Option[String] = opts.responseFormat.orElse(ttsOptions.responseFormat)
     val speedOpt: Option[Double] = opts.speed.orElse(ttsOptions.speed)
     val body = Json.obj(
@@ -159,12 +160,12 @@ class OpenRouterAudioModelClient(val api: OpenRouterApi, val ttsOptions: OpenRou
     }
   }
 
-  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
+  override def speechToText(opts: AudioModelClientSpeechToTextInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, AudioTranscriptionResponse]] = {
     val model = opts.model.orElse(sttOptions.model).getOrElse(OpenRouterApi.defaultSttModel)
     val language = opts.language.orElse(sttOptions.language)
     val temperature = opts.temperature.orElse(sttOptions.temperature)
     val format = resolveSttFormat(opts)
-    opts.file.runFold(ByteString.empty)(_ ++ _)(env.otoroshiMaterializer).flatMap { bytes =>
+    opts.file.runFold(ByteString.empty)(_ ++ _)(using env.otoroshiMaterializer).flatMap { bytes =>
       val body = Json.obj(
         "model" -> model,
         "input_audio" -> Json.obj(
@@ -179,7 +180,7 @@ class OpenRouterAudioModelClient(val api: OpenRouterApi, val ttsOptions: OpenRou
       api.rawCall("POST", "/audio/transcriptions", body.some).map { response =>
         if (response.status == 200) {
           val resp = response.json
-          AudioTranscriptionResponse(resp.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(resp.asObject, response.headers.mapValues(_.last))).right
+          AudioTranscriptionResponse(resp.select("text").asString, AudioTranscriptionResponseMetadata.fromOpenAiResponse(resp.asObject, response.headers.view.mapValues(_.last).toMap)).right
         } else {
           Left(Json.obj("error" -> "Bad response", "body" -> s"Failed with status ${response.status}: ${response.body}"))
         }
@@ -213,8 +214,8 @@ class OpenRouterImageModelClient(val api: OpenRouterApi, val genOptions: OpenRou
   override def supportsEdit: Boolean = editOptions.enabled
 
   // turn an uploaded image (a streamed source of bytes) into the base64 data URL OpenRouter expects
-  private def imageToDataUrl(img: ImageFile)(implicit ec: ExecutionContext, env: Env): Future[String] = {
-    img.bytes.runFold(ByteString.empty)(_ ++ _)(env.otoroshiMaterializer).map { bytes =>
+  private def imageToDataUrl(img: ImageFile)(using ec: ExecutionContext, env: Env): Future[String] = {
+    img.bytes.runFold(ByteString.empty)(_ ++ _)(using env.otoroshiMaterializer).map { bytes =>
       val ct = Option(img.contentType).filter(_.startsWith("image/")).getOrElse("image/png")
       s"data:${ct};base64,${bytes.encodeBase64.utf8String}"
     }
@@ -235,7 +236,7 @@ class OpenRouterImageModelClient(val api: OpenRouterApi, val genOptions: OpenRou
   private def parseResponse(resp: WSResponse): Either[JsValue, ImagesGenResponse] = {
     if (resp.status == 200) {
       val json = resp.json
-      val headers = resp.headers.mapValues(_.last)
+      val headers = resp.headers.view.mapValues(_.last).toMap
       val message = json.select("choices").asOpt[Seq[JsObject]].flatMap(_.headOption)
         .flatMap(_.select("message").asOpt[JsObject]).getOrElse(Json.obj())
       val text = message.select("content").asOptString.filter(_.nonEmpty)
@@ -275,13 +276,13 @@ class OpenRouterImageModelClient(val api: OpenRouterApi, val genOptions: OpenRou
     }
   }
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel = opts.model.orElse(genOptions.model).getOrElse(OpenRouterApi.defaultImageModel)
     val body = chatBody(finalModel, opts.prompt, Seq.empty, genOptions.modalities)
     api.rawCall("POST", "/chat/completions", body.some).map(parseResponse)
   }
 
-  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def edit(opts: ImageModelClientEditionInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel = opts.model.orElse(editOptions.model).getOrElse(OpenRouterApi.defaultImageModel)
     Future.sequence(opts.images.map(imageToDataUrl)).flatMap { dataUrls =>
       val body = chatBody(finalModel, opts.prompt, dataUrls, editOptions.modalities)
@@ -342,16 +343,16 @@ class OpenRouterVideoModelClient(val api: OpenRouterApi, val genOptions: OpenRou
   }
 
   // poll GET /videos/{id} until the job completes, fails, or we run out of attempts
-  private def pollUntilDone(jobId: String, attemptsLeft: Int)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  private def pollUntilDone(jobId: String, attemptsLeft: Int)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     if (attemptsLeft <= 0) {
       Left(Json.obj("error" -> "video generation timed out while polling", "job_id" -> jobId)).vfuture
     } else {
-      akka.pattern.after(genOptions.pollInterval, env.otoroshiScheduler)(Future.successful(()))(ec).flatMap { _ =>
+      org.apache.pekko.pattern.after(genOptions.pollInterval, env.otoroshiScheduler)(Future.successful(()))(using ec).flatMap { _ =>
         api.rawCall("GET", s"/videos/${jobId}", None).flatMap { resp =>
           if (resp.status == 200) {
             val json = resp.json
             json.select("status").asOptString.getOrElse("pending").toLowerCase match {
-              case "completed" => buildResponse(json, resp.headers.mapValues(_.last)).vfuture
+              case "completed" => buildResponse(json, resp.headers.view.mapValues(_.last).toMap).vfuture
               case s if terminalFailures.contains(s) => Left(Json.obj("error" -> s"video generation $s", "body" -> json)).vfuture
               case _ => pollUntilDone(jobId, attemptsLeft - 1)
             }
@@ -363,7 +364,7 @@ class OpenRouterVideoModelClient(val api: OpenRouterApi, val genOptions: OpenRou
     }
   }
 
-  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
+  override def generate(opts: VideoModelClientTextToVideoInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, VideosGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse(OpenRouterApi.defaultVideoModel)
     // gateway duration is a string (e.g. "8" or "5s"); OpenRouter wants an integer number of seconds
     val durationOpt: Option[Int] = opts.duration.flatMap(d => "\\d+".r.findFirstIn(d.trim)).flatMap(s => scala.util.Try(s.toInt).toOption).orElse(genOptions.duration)
@@ -383,13 +384,13 @@ class OpenRouterVideoModelClient(val api: OpenRouterApi, val genOptions: OpenRou
           case None => Left(Json.obj("error" -> "no job id in response", "body" -> json)).vfuture
           case Some(jobId) =>
             json.select("status").asOptString.getOrElse("pending").toLowerCase match {
-              case "completed" => buildResponse(json, resp.headers.mapValues(_.last)).vfuture
+              case "completed" => buildResponse(json, resp.headers.view.mapValues(_.last).toMap).vfuture
               case s if terminalFailures.contains(s) => Left(Json.obj("error" -> s"video generation $s", "body" -> json)).vfuture
               case _ => pollUntilDone(jobId, genOptions.maxPollAttempts)
             }
         }
       } else {
-        Left(Json.obj("error" -> "Bad response", "status" -> resp.status, "body" -> resp.body)).vfuture
+        Left(Json.obj("error" -> "Bad response", "status" -> resp.status, "body" -> (resp.body: String))).vfuture
       }
     }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/opensearch_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/opensearch_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object OpenSearchEmbeddingStoreClient {
   lazy val logger = Logger("OpenSearchEmbeddingStoreClient")
@@ -37,10 +38,10 @@ class OpenSearchEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
     base ++ auth
   }
 
-  private def ensureIndex()(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  private def ensureIndex()(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .head()
       .flatMap { resp =>
@@ -49,7 +50,7 @@ class OpenSearchEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
         } else {
           env.Ws
             .url(s"$baseUrl/$index")
-            .withHttpHeaders(headers: _*)
+            .withHttpHeaders(headers*)
             .withRequestTimeout(timeout)
             .put(Json.obj(
               "settings" -> Json.obj(
@@ -77,20 +78,20 @@ class OpenSearchEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
               if (createResp.status == 200 || createResp.status == 201) {
                 Right(())
               } else {
-                Left(Json.obj("error" -> s"OpenSearch index creation error: ${createResp.status}", "body" -> createResp.body))
+                Left(Json.obj("error" -> s"OpenSearch index creation error: ${createResp.status}", "body" -> (createResp.body: String)))
               }
             }
         }
       }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureIndex().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(_) =>
         env.Ws
           .url(s"$baseUrl/$index/_doc/${options.id}")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .put(Json.obj(
             "doc_id" -> options.id,
@@ -101,31 +102,31 @@ class OpenSearchEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
             if (resp.status == 200 || resp.status == 201) {
               Right(())
             } else {
-              Left(Json.obj("error" -> s"OpenSearch add error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"OpenSearch add error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${options.id}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status == 200 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"OpenSearch delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"OpenSearch delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     env.Ws
       .url(s"$baseUrl/$index/_search")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "size" -> options.maxResults,
@@ -155,7 +156,7 @@ class OpenSearchEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
           }
           Right(EmbeddingSearchResponse(matches))
         } else {
-          Left(Json.obj("error" -> s"OpenSearch search error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"OpenSearch search error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/opensearch_persistentmemory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/opensearch_persistentmemory.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object OpenSearchPersistentMemoryClient {
   lazy val logger = Logger("OpenSearchPersistentMemoryClient")
@@ -36,10 +37,10 @@ class OpenSearchPersistentMemoryClient(val config: JsObject, _memoryId: String) 
 
   private def docId(sessionId: String): String = s"${_memoryId}_${sessionId}"
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .put(Json.obj(
         "memory_id" -> _memoryId,
@@ -50,15 +51,15 @@ class OpenSearchPersistentMemoryClient(val config: JsObject, _memoryId: String) 
         if (resp.status == 200 || resp.status == 201) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"OpenSearch update error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"OpenSearch update error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .map { resp =>
@@ -69,22 +70,22 @@ class OpenSearchPersistentMemoryClient(val config: JsObject, _memoryId: String) 
         } else if (resp.status == 404) {
           Right(Seq.empty[PersistedChatMessage])
         } else {
-          Left(Json.obj("error" -> s"OpenSearch get error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"OpenSearch get error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/$index/_doc/${docId(sessionId)}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status == 200 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"OpenSearch delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"OpenSearch delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/ovh.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/ovh.scala
@@ -1,16 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl.{Framing, Source}
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import org.apache.pekko.stream.scaladsl.{Framing, Source}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import com.github.blemale.scaffeine.Scaffeine
-import otoroshi.api.OtoroshiEnvHolder
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json, __}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
@@ -68,7 +68,7 @@ object OVHAiEndpointsApi {
   val cache = Scaffeine().expireAfterWrite(1.hour).build[String, JsValue]()
   val apikey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJyb2xlIjogImFub24iLAogICJpc3MiOiAic3VwYWJhc2UiLAogICJpYXQiOiAxNzEwNzE2NDAwLAogICJleHAiOiAxODY4NDgyODAwCn0.Jty_eO4oWqLm4Lx_LfbpRW5WESXYXtT2humbBq2Pal8" // good until 2029
 
-  def getModelsList()(implicit ec: ExecutionContext, env: Env): Future[Either[String, List[OVHAiEndpointsApiModel]]] = {
+  def getModelsList()(using ec: ExecutionContext, env: Env): Future[Either[String, List[OVHAiEndpointsApiModel]]] = {
     val key = "all_models"
     cache.getIfPresent(key) match {
       case Some(models) =>
@@ -97,14 +97,14 @@ object OVHAiEndpointsApi {
     }
   }
 
-  def getModel(model: String)(implicit ec: ExecutionContext, env: Env): Future[Either[String, OVHAiEndpointsApiModel]] = {
+  def getModel(model: String)(using ec: ExecutionContext, env: Env): Future[Either[String, OVHAiEndpointsApiModel]] = {
     val key = model
     cache.getIfPresent(key) match {
       case Some(model) =>
         OVHAiEndpointsApiModel(model).rightf
       case None => {
         getModelsList().flatMap {
-          case Left(err) => s"model url not found for '${model}'".leftf
+          case Left(_) => s"model url not found for '${model}'".leftf
           case Right(modelRefs) => {
             modelRefs.find(_.name == model) match {
               case None => s"model url not found in model refs for '${model}'".leftf
@@ -133,12 +133,12 @@ object OVHAiEndpointsApi {
     }
   }
 
-  def extractModelUrlsMap()(implicit ec: ExecutionContext, env: Env): Future[Unit] = {
+  def extractModelUrlsMap()(using ec: ExecutionContext, env: Env): Future[Unit] = {
     cache.getIfPresent("model_urls_map") match {
       case Some(_) => ().vfuture
       case None => {
         OVHAiEndpointsApi.getModelsList().flatMap {
-          case Left(err) => ().vfuture
+          case Left(_) => ().vfuture
           case Right(list) => {
             list.filter(v => v.isLlm && v.isAvailable).mapAsync { model =>
               env.Ws.url(model.documentation_url).get().map { r =>
@@ -150,7 +150,7 @@ object OVHAiEndpointsApi {
                 models.headOption.map(m => (m, model.gradio_url))
               }
             }.map(_.flatten).map { tuples =>
-              cache.put("model_urls_map", JsObject(tuples.toMap.mapValues(_.json)))
+              cache.put("model_urls_map", JsObject(tuples.toMap.view.mapValues(_.json).toMap))
             }
           }
         }
@@ -158,7 +158,7 @@ object OVHAiEndpointsApi {
     }
   }
 
-  def getRealModelNames()(implicit ec: ExecutionContext, env: Env): Future[Either[String, List[String]]] = {
+  def getRealModelNames()(using ec: ExecutionContext, env: Env): Future[Either[String, List[String]]] = {
     cache.getIfPresent("model_urls_map") match {
       case Some(obj) => obj.asObject.value.keys.toList.rightf
       case None => extractModelUrlsMap().map { _ =>
@@ -167,7 +167,7 @@ object OVHAiEndpointsApi {
     }
   }
 
-  def getUrlFromModel(modelName: String)(implicit ec: ExecutionContext, env: Env): Future[Either[String, String]] = {
+  def getUrlFromModel(modelName: String)(using ec: ExecutionContext, env: Env): Future[Either[String, String]] = {
     cache.getIfPresent("model_urls_map") match {
       case Some(obj) =>
         obj.asObject.value.get(modelName).map(_.asString).orElse(
@@ -188,13 +188,13 @@ class OVHAiEndpointsApi(baseDomain: String = OVHAiEndpointsApi.baseDomain, token
   val supportsCompletion: Boolean = true
   val supportsStreaming: Boolean = true
 
-  def rawCall(model: String, method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[Either[String, WSResponse]] = {
+  def rawCall(model: String, method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[Either[String, WSResponse]] = {
     //val url = OVHAiEndpointsModels.modelUrls.get(model).getOrElse(s"${model.toLowerCase().replaceAll("\\.", "")}.${baseDomain}")
-    OVHAiEndpointsApi.getUrlFromModel(model)(env.otoroshiExecutionContext, env).flatMap {
+    OVHAiEndpointsApi.getUrlFromModel(model)(using env.otoroshiExecutionContext, env).flatMap {
       case Left(err) => err.leftf
       case Right(url) => {
         val furl = s"${url}${path}"
-        ProviderHelpers.logCall("OVH", method, furl, body)(env)
+        ProviderHelpers.logCall("OVH", method, furl, body)(using env)
         env.Ws
           .url(furl)
           .withHttpHeaders(
@@ -213,23 +213,23 @@ class OVHAiEndpointsApi(baseDomain: String = OVHAiEndpointsApi.baseDomain, token
     }
   }
 
-  def call(model: String, method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[Either[JsValue, OVHAiEndpointsApiResponse]] = {
+  def call(model: String, method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[Either[JsValue, OVHAiEndpointsApiResponse]] = {
     rawCall(model, method, path, body)
       .map {
         case Left(err) => Left(err.json)
         case Right(r) => ProviderHelpers.wrapResponse("OVH", r, env) { resp =>
-          OVHAiEndpointsApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+          OVHAiEndpointsApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
         }
       }
   }
 
-  def stream(model: String, method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  def stream(model: String, method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     // val url = OVHAiEndpointsModels.modelUrls.get(model).getOrElse(s"${model.toLowerCase().replaceAll("\\.", "")}.${baseDomain}")
-    OVHAiEndpointsApi.getUrlFromModel(model)(env.otoroshiExecutionContext, env).flatMap {
+    OVHAiEndpointsApi.getUrlFromModel(model)(using env.otoroshiExecutionContext, env).flatMap {
       case Left(err) => err.json.leftf
       case Right(url) => {
         val furl = s"${url}${path}"
-        ProviderHelpers.logStream("OVH", method, furl, body)(env)
+        ProviderHelpers.logStream("OVH", method, furl, body)(using env)
         env.Ws
           .url(s"${url}${path}")
           .withHttpHeaders(
@@ -304,7 +304,7 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
 
   override def computeModel(payload: JsValue): Option[String] = payload.select("model").asOpt[String].orElse(options.model.some)
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     if (raw) {
       api.rawCall(options.model, "GET", "/api/openai_compat/v1/models", None).map {
         case Left(err) =>
@@ -319,14 +319,14 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
         }
       }
     } else {
-      OVHAiEndpointsApi.getRealModelNames()(ec, api.env).map {
-        case Left(err) => Right(OVHAiEndpointsModels.backup_model_urls.keys.toList)
+      OVHAiEndpointsApi.getRealModelNames()(using ec, api.env).map {
+        case Left(_) => Right(OVHAiEndpointsModels.backup_model_urls.keys.toList)
         case Right(list) => list.right
       }
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -368,7 +368,6 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -380,7 +379,7 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
     }
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val obody = originalBody.asObject - "messages" - "provider"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(obody) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -423,7 +422,6 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
               true
@@ -450,7 +448,7 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider" - "prompt"
     val mergedOptions = if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -490,7 +488,6 @@ class OVHAiEndpointsChatClient(api: OVHAiEndpointsApi, options: OVHAiEndpointsCh
             val newArr = arr ++ Seq(slug)
             obj ++ Json.obj("ai" -> newArr)
           }
-          case Some(other) => other
           case None => Json.obj("ai" -> Seq(slug))
         }
         val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/pgpool_manager.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/pgpool_manager.scala
@@ -1,12 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import io.vertx.pgclient.{PgConnectOptions, PgPool}
-import io.vertx.sqlclient.{PoolOptions, Row, Tuple}
+import io.vertx.pgclient.{PgBuilder, PgConnectOptions}
+import io.vertx.sqlclient.{Pool, PoolOptions, Row, Tuple}
 import play.api.Logger
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 // ---------------------------------------------------------------------------
 //  Shared PgPool manager — one pool per distinct PostgreSQL URI
@@ -16,10 +16,10 @@ object PgPoolManager {
 
   private val logger = Logger("PgPoolManager")
 
-  private val pools = new TrieMap[String, PgPool]()
+  private val pools = new TrieMap[String, Pool]()
 
   // --- Vert.x Future → Scala Future conversion ---
-  implicit class VertxFutureToScala[A](val future: io.vertx.core.Future[A]) extends AnyVal {
+  extension [A](future: io.vertx.core.Future[A]) {
     def scala: Future[A] = {
       val promise = Promise[A]()
       future.onSuccess(a => promise.trySuccess(a))
@@ -28,14 +28,16 @@ object PgPoolManager {
     }
   }
 
-  def getPool(uri: String): PgPool = synchronized {
+  def getPool(uri: String): Pool = synchronized {
     pools.get(uri) match {
       case Some(pool) => pool
       case None =>
         logger.info(s"Creating new PgPool for: $uri")
         val connectOptions = PgConnectOptions.fromUri(uri)
         val poolOptions = new PoolOptions().setMaxSize(10)
-        val pool = PgPool.pool(connectOptions, poolOptions)
+        // vertx 5 dropped `PgPool.pool(...)`: pools are now assembled through PgBuilder and
+        // handed back as the generic io.vertx.sqlclient.Pool
+        val pool = PgBuilder.pool().connectingTo(connectOptions).`with`(poolOptions).build()
         pools.put(uri, pool)
         pool
     }
@@ -57,7 +59,7 @@ object PgPoolManager {
 
   // --- Query helpers ---
 
-  def query(pool: PgPool, sql: String, params: Seq[AnyRef] = Seq.empty)(implicit ec: ExecutionContext): Future[Seq[Row]] = {
+  def query(pool: Pool, sql: String, params: Seq[AnyRef] = Seq.empty)(using ec: ExecutionContext): Future[Seq[Row]] = {
     val tuple = if (params.isEmpty) Tuple.tuple() else Tuple.from(params.toArray)
     val isRead = sql.trim.toLowerCase.startsWith("select")
     val fut = if (isRead) {
@@ -68,7 +70,7 @@ object PgPoolManager {
     fut.scala.map(_.asScala.toSeq)
   }
 
-  def exec(pool: PgPool, sql: String, params: Seq[AnyRef] = Seq.empty)(implicit ec: ExecutionContext): Future[Unit] = {
+  def exec(pool: Pool, sql: String, params: Seq[AnyRef] = Seq.empty)(using ec: ExecutionContext): Future[Unit] = {
     val tuple = if (params.isEmpty) Tuple.tuple() else Tuple.from(params.toArray)
     pool.preparedQuery(sql).execute(tuple).scala.map(_ => ())
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/pinecone_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/pinecone_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object PineconeEmbeddingStoreClient {
   lazy val logger = Logger("PineconeEmbeddingStoreClient")
@@ -28,10 +29,10 @@ class PineconeEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
     "Api-Key" -> apiKey
   )
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/vectors/upsert")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "vectors" -> Json.arr(Json.obj(
@@ -47,15 +48,15 @@ class PineconeEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
         if (resp.status == 200) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Pinecone upsert error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Pinecone upsert error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/vectors/delete")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "ids" -> Json.arr(options.id),
@@ -65,15 +66,15 @@ class PineconeEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
         if (resp.status == 200) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Pinecone delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Pinecone delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     env.Ws
       .url(s"$baseUrl/query")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "vector" -> Json.toJson(options.embedding.vector),
@@ -98,7 +99,7 @@ class PineconeEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
           }
           Right(EmbeddingSearchResponse(matches))
         } else {
-          Left(Json.obj("error" -> s"Pinecone query error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Pinecone query error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/postgresql_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/postgresql_embeddingstore.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,8 +17,8 @@ object PostgresqlEmbeddingStoreClient {
 
 class PostgresqlEmbeddingStoreClient(val config: JsObject, _storeId: String) extends EmbeddingStoreClient {
 
-  import PgPoolManager._
-  import PostgresqlEmbeddingStoreClient._
+  import PgPoolManager.*
+  import PostgresqlEmbeddingStoreClient.*
 
   private lazy val connection: JsObject = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
   private lazy val uri: String = connection.select("uri").asOptString.getOrElse("postgresql://otoroshi:otoroshi@localhost:5432/otoroshi")
@@ -32,7 +32,7 @@ class PostgresqlEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
   private def parseVector(str: String): Array[Float] =
     str.stripPrefix("[").stripSuffix("]").split(",").map(_.trim.toFloat)
 
-  private def ensureTable()(implicit ec: ExecutionContext): Future[Unit] = {
+  private def ensureTable()(using ec: ExecutionContext): Future[Unit] = {
     val key = s"$uri:$table"
     if (verifiedTables.contains(key)) {
       Future.successful(())
@@ -55,7 +55,7 @@ class PostgresqlEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
     }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureTable().flatMap { _ =>
       val vectorStr = vectorToString(options.embedding.vector)
       exec(pool,
@@ -67,7 +67,7 @@ class PostgresqlEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     exec(pool, s"DELETE FROM $table WHERE id = $$1", Seq(options.id))
       .map(_ => Right(()))
       .recover { case e: Throwable =>
@@ -75,7 +75,7 @@ class PostgresqlEmbeddingStoreClient(val config: JsObject, _storeId: String) ext
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     ensureTable().flatMap { _ =>
       val vectorStr = vectorToString(options.embedding.vector)
       query(pool,

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/postgresql_persistentmemory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/postgresql_persistentmemory.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,8 +16,8 @@ object PostgresqlPersistentMemoryClient {
 
 class PostgresqlPersistentMemoryClient(val config: JsObject, _memoryId: String) extends PersistentMemoryClient {
 
-  import PgPoolManager._
-  import PostgresqlPersistentMemoryClient._
+  import PgPoolManager.*
+  import PostgresqlPersistentMemoryClient.*
 
   private lazy val connection: JsObject = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
   private lazy val uri: String = connection.select("uri").asOptString.getOrElse("postgresql://otoroshi:otoroshi@localhost:5432/otoroshi")
@@ -27,7 +27,7 @@ class PostgresqlPersistentMemoryClient(val config: JsObject, _memoryId: String) 
 
   private def docId(sessionId: String): String = s"${_memoryId}_${sessionId}"
 
-  private def ensureTable()(implicit ec: ExecutionContext): Future[Unit] = {
+  private def ensureTable()(using ec: ExecutionContext): Future[Unit] = {
     val key = s"$uri:$table"
     if (verifiedTables.contains(key)) {
       Future.successful(())
@@ -51,7 +51,7 @@ class PostgresqlPersistentMemoryClient(val config: JsObject, _memoryId: String) 
     }
   }
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureTable().flatMap { _ =>
       val json = Json.stringify(JsArray(messages.map(_.raw)))
       exec(pool,
@@ -63,7 +63,7 @@ class PostgresqlPersistentMemoryClient(val config: JsObject, _memoryId: String) 
     }
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     ensureTable().flatMap { _ =>
       query(pool,
         s"SELECT messages FROM $table WHERE id = $$1",
@@ -83,7 +83,7 @@ class PostgresqlPersistentMemoryClient(val config: JsObject, _memoryId: String) 
     }
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     exec(pool, s"DELETE FROM $table WHERE id = $$1", Seq(docId(sessionId)))
       .map(_ => Right(()))
       .recover { case e: Throwable =>

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/qdrant_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/qdrant_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object QdrantEmbeddingStoreClient {
   lazy val logger = Logger("QdrantEmbeddingStoreClient")
@@ -32,10 +33,10 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
     }
   }
 
-  private def ensureCollection()(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  private def ensureCollection()(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/collections/$collectionName")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .flatMap { resp =>
@@ -44,7 +45,7 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
         } else {
           env.Ws
             .url(s"$baseUrl/collections/$collectionName")
-            .withHttpHeaders(headers: _*)
+            .withHttpHeaders(headers*)
             .withRequestTimeout(timeout)
             .put(Json.obj(
               "vectors" -> Json.obj(
@@ -56,20 +57,20 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
               if (createResp.status == 200 || createResp.status == 201) {
                 Right(())
               } else {
-                Left(Json.obj("error" -> s"Qdrant collection creation error: ${createResp.status}", "body" -> createResp.body))
+                Left(Json.obj("error" -> s"Qdrant collection creation error: ${createResp.status}", "body" -> (createResp.body: String)))
               }
             }
         }
       }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureCollection().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(_) =>
         env.Ws
           .url(s"$baseUrl/collections/$collectionName/points")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .put(Json.obj(
             "points" -> Json.arr(Json.obj(
@@ -85,16 +86,16 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
             if (resp.status == 200) {
               Right(())
             } else {
-              Left(Json.obj("error" -> s"Qdrant add error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"Qdrant add error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/collections/$collectionName/points/delete")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "points" -> Json.arr(options.id)
@@ -103,15 +104,15 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
         if (resp.status == 200) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Qdrant delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Qdrant delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     env.Ws
       .url(s"$baseUrl/collections/$collectionName/points/search")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(Json.obj(
         "vector" -> Json.toJson(options.embedding.vector),
@@ -133,7 +134,7 @@ class QdrantEmbeddingStoreClient(val config: JsObject, _storeId: String) extends
           }
           Right(EmbeddingSearchResponse(matches))
         } else {
-          Left(Json.obj("error" -> s"Qdrant search error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Qdrant search error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/redis_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/redis_embeddingstore.scala
@@ -1,19 +1,19 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import io.lettuce.core.codec.StringCodec
 import io.lettuce.core.output.{IntegerOutput, NestedMultiOutput, StatusOutput}
 import io.lettuce.core.protocol.{CommandArgs, ProtocolKeyword}
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 // ---------------------------------------------------------------------------
 //  Redis Stack (RediSearch) backed EmbeddingStoreClient
@@ -27,10 +27,10 @@ object RedisEmbeddingStoreClient {
   private val verifiedIndices = new TrieMap[String, Boolean]()
   def resetVerifiedIndex(indexName: String): Unit = verifiedIndices.remove(indexName)
 
-  private def cmd(name: String): ProtocolKeyword = new ProtocolKeyword {
-    private val bytes = name.getBytes(StandardCharsets.US_ASCII)
+  private def cmd(cmdName: String): ProtocolKeyword = new ProtocolKeyword {
+    private val bytes = cmdName.getBytes(StandardCharsets.US_ASCII)
     override def getBytes: Array[Byte] = bytes
-    override def name(): String = name
+    override def name(): String = cmdName
   }
 
   val FT_CREATE: ProtocolKeyword = cmd("FT.CREATE")
@@ -41,7 +41,7 @@ object RedisEmbeddingStoreClient {
 
 class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends EmbeddingStoreClient {
 
-  import RedisEmbeddingStoreClient._
+  import RedisEmbeddingStoreClient.*
 
   private lazy val connection: JsObject = config.select("connection").asOpt[JsObject].getOrElse(Json.obj())
   private lazy val url: String = connection.select("url").asOptString.getOrElse("redis://localhost:6379")
@@ -75,7 +75,7 @@ class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends
 
   // ---- index lifecycle ----
 
-  private def ensureIndex()(implicit ec: ExecutionContext): Future[Unit] = {
+  private def ensureIndex()(using ec: ExecutionContext): Future[Unit] = {
     if (verifiedIndices.contains(indexName)) {
       Future.successful(())
     } else {
@@ -111,7 +111,7 @@ class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends
 
   // ---- EmbeddingStoreClient impl ----
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureIndex().flatMap { _ =>
       val key = s"${keyPrefix}${options.id}"
       val vectorBytes = floatsToBytes(options.embedding.vector)
@@ -135,7 +135,7 @@ class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     val key = s"${keyPrefix}${options.id}"
     toFuture(redisConn.async().del(key))
       .map(_ => Right(()))
@@ -144,7 +144,7 @@ class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     ensureIndex().flatMap { _ =>
       val vectorBytes = floatsToBytes(options.embedding.vector)
 
@@ -180,7 +180,7 @@ class RedisEmbeddingStoreClient (val config: JsObject, _storeId: String) extends
             if (i + 1 < list.size) {
               val docKey = list(i).toString
               val fields = list(i + 1) match {
-                case l: java.util.List[_] => l.asScala.map(_.toString).toList
+                case l: java.util.List[?] => l.asScala.map(_.toString).toList
                 case _ => List.empty[String]
               }
               val fieldMap = fields.grouped(2).collect { case List(k, v) => k -> v }.toMap

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/redis_persistentmemory.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/redis_persistentmemory.scala
@@ -1,12 +1,12 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import io.lettuce.core.{RedisClient => LettuceRedisClient}
 import io.lettuce.core.api.StatefulRedisConnection
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -98,7 +98,7 @@ class RedisPersistentMemoryClient(val config: JsObject, _memoryId: String) exten
     promise.future
   }
 
-  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def updateMessages(sessionId: String, messages: Seq[PersistedChatMessage])(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     val json = Json.stringify(JsArray(messages.map(_.raw)))
     toFuture(conn.async().set(redisKey(sessionId), json))
       .map(_ => Right(()))
@@ -107,7 +107,7 @@ class RedisPersistentMemoryClient(val config: JsObject, _memoryId: String) exten
       }
   }
 
-  override def getMessages(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
+  override def getMessages(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Seq[PersistedChatMessage]]] = {
     toFuture(conn.async().get(redisKey(sessionId)))
       .map {
         case null => Right(Seq.empty[PersistedChatMessage])
@@ -120,7 +120,7 @@ class RedisPersistentMemoryClient(val config: JsObject, _memoryId: String) exten
       }
   }
 
-  override def clearMemory(sessionId: String)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def clearMemory(sessionId: String)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     toFuture(conn.async().del(redisKey(sessionId)))
       .map(_ => Right(()))
       .recover { case e: Throwable =>

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/searchengines.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/searchengines.scala
@@ -1,15 +1,16 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import otoroshi_plugins.com.cloud.apim.extensions.aigateway._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import otoroshi_plugins.com.cloud.apim.extensions.aigateway.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import java.net.URLEncoder
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
 
 object SearchEngineHelpers {
@@ -28,9 +29,9 @@ object StaanApi {
 }
 
 class StaanApi(baseUrl: String = StaanApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Staan", method, url, body)(env)
+    ProviderHelpers.logCall("Staan", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -58,7 +59,7 @@ object StaanSearchOptions {
 }
 
 class StaanSearchClient(api: StaanApi, options: StaanSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val body = Json.obj("q" -> opts.query)
       .applyOnWithOpt(opts.market.orElse(options.market).orElse("fr-FR".some)) { case (o, v) => o ++ Json.obj("market" -> v) }
       .applyOnWithOpt(opts.maxResults.orElse(options.count)) { case (o, v) => o ++ Json.obj("count" -> v) }
@@ -83,7 +84,7 @@ class StaanSearchClient(api: StaanApi, options: StaanSearchOptions, id: String) 
         }
         SearchEngineResponse("staan", opts.query, None, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from staan", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from staan", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -98,9 +99,9 @@ object TavilyApi {
 }
 
 class TavilyApi(baseUrl: String = TavilyApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Tavily", method, url, body)(env)
+    ProviderHelpers.logCall("Tavily", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -127,7 +128,7 @@ object TavilySearchOptions {
 }
 
 class TavilySearchClient(api: TavilyApi, options: TavilySearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val body = Json.obj("query" -> opts.query)
       .applyOnWithOpt(opts.maxResults.orElse(options.maxResults)) { case (o, v) => o ++ Json.obj("max_results" -> v) }
       .applyOnWithOpt(options.searchDepth) { case (o, v) => o ++ Json.obj("search_depth" -> v) }
@@ -150,7 +151,7 @@ class TavilySearchClient(api: TavilyApi, options: TavilySearchOptions, id: Strin
         }
         SearchEngineResponse("tavily", opts.query, json.select("answer").asOptString, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from tavily", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from tavily", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -165,9 +166,9 @@ object BraveSearchApi {
 }
 
 class BraveSearchApi(baseUrl: String = BraveSearchApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawGet(path: String)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawGet(path: String)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Brave", "GET", url, None)(env)
+    ProviderHelpers.logCall("Brave", "GET", url, None)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -191,7 +192,7 @@ object BraveSearchOptions {
 }
 
 class BraveSearchClient(api: BraveSearchApi, options: BraveSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val params = Seq(
       "q" -> opts.query,
       "count" -> opts.maxResults.map(_.toString).getOrElse(""),
@@ -215,7 +216,7 @@ class BraveSearchClient(api: BraveSearchApi, options: BraveSearchOptions, id: St
         }
         SearchEngineResponse("brave", opts.query, None, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from brave", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from brave", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -230,9 +231,9 @@ object SearXNGApi {
 }
 
 class SearXNGApi(baseUrl: String = SearXNGApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawGet(path: String)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawGet(path: String)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("SearXNG", "GET", url, None)(env)
+    ProviderHelpers.logCall("SearXNG", "GET", url, None)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders("Accept" -> "application/json")
@@ -255,7 +256,7 @@ object SearXNGSearchOptions {
 }
 
 class SearXNGSearchClient(api: SearXNGApi, options: SearXNGSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val params = Seq(
       "q" -> opts.query,
       "format" -> "json",
@@ -281,7 +282,7 @@ class SearXNGSearchClient(api: SearXNGApi, options: SearXNGSearchOptions, id: St
         }
         SearchEngineResponse("searxng", opts.query, json.select("answers").asOpt[Seq[String]].flatMap(_.headOption), results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from searxng", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from searxng", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -297,9 +298,9 @@ object GoogleCseApi {
 
 class GoogleCseApi(baseUrl: String = GoogleCseApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
   val apiKey: String = token
-  def rawGet(path: String)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawGet(path: String)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("GoogleCse", "GET", url, None)(env)
+    ProviderHelpers.logCall("GoogleCse", "GET", url, None)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders("Accept" -> "application/json")
@@ -319,7 +320,7 @@ object GoogleCseSearchOptions {
 }
 
 class GoogleCseSearchClient(api: GoogleCseApi, options: GoogleCseSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val params = Seq(
       "key" -> api.apiKey,
       "cx" -> options.cx.getOrElse(""),
@@ -343,7 +344,7 @@ class GoogleCseSearchClient(api: GoogleCseApi, options: GoogleCseSearchOptions, 
         }
         SearchEngineResponse("google", opts.query, None, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from google custom search", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from google custom search", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -358,9 +359,9 @@ object SearchApiApi {
 }
 
 class SearchApiApi(baseUrl: String = SearchApiApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawGet(path: String)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawGet(path: String)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("SearchApi", "GET", url, None)(env)
+    ProviderHelpers.logCall("SearchApi", "GET", url, None)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -384,7 +385,7 @@ object SearchApiSearchOptions {
 }
 
 class SearchApiSearchClient(api: SearchApiApi, options: SearchApiSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val params = Seq(
       "engine" -> options.engine,
       "q" -> opts.query,
@@ -407,7 +408,7 @@ class SearchApiSearchClient(api: SearchApiApi, options: SearchApiSearchOptions, 
         }
         SearchEngineResponse("searchapi", opts.query, None, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
       } else {
-        Left(Json.obj("error" -> "bad response from searchapi", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from searchapi", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -424,9 +425,9 @@ object DuckDuckGoApi {
 }
 
 class DuckDuckGoApi(baseUrl: String = DuckDuckGoApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawGet(path: String)(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawGet(path: String)(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("DuckDuckGo", "GET", url, None)(env)
+    ProviderHelpers.logCall("DuckDuckGo", "GET", url, None)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders("Accept" -> "application/json")
@@ -451,7 +452,7 @@ class DuckDuckGoSearchClient(api: DuckDuckGoApi, options: DuckDuckGoSearchOption
     }
   }
 
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val params = Seq(
       "q" -> opts.query,
       "format" -> "json",
@@ -483,10 +484,10 @@ class DuckDuckGoSearchClient(api: DuckDuckGoApi, options: DuckDuckGoSearchOption
           val results = opts.maxResults.map(n => all.take(n)).getOrElse(all)
           SearchEngineResponse("duckduckgo", opts.query, json.select("AbstractText").asOptString.filter(_.nonEmpty), results, json.asOpt[JsObject].getOrElse(Json.obj())).right
         } catch {
-          case t: Throwable => Left(Json.obj("error" -> "bad response from duckduckgo", "status" -> resp.status, "body" -> resp.body))
+          case _: Throwable => Left(Json.obj("error" -> "bad response from duckduckgo", "status" -> resp.status, "body" -> (resp.body: String)))
         }
       } else {
-        Left(Json.obj("error" -> "bad response from duckduckgo", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from duckduckgo", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -501,9 +502,9 @@ object ExaApi {
 }
 
 class ExaApi(baseUrl: String = ExaApi.baseUrl, token: String, timeout: FiniteDuration = 30.seconds, env: Env) {
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("Exa", method, url, body)(env)
+    ProviderHelpers.logCall("Exa", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -531,7 +532,7 @@ object ExaSearchOptions {
 }
 
 class ExaSearchClient(api: ExaApi, options: ExaSearchOptions, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val contents = Json.obj()
       .applyOnIf(options.highlights) { o => o ++ Json.obj("highlights" -> true) }
       .applyOnIf(options.text) { o => o ++ Json.obj("text" -> true) }
@@ -564,10 +565,10 @@ class ExaSearchClient(api: ExaApi, options: ExaSearchOptions, id: String) extend
           }
           SearchEngineResponse("exa", opts.query, None, results, json.asOpt[JsObject].getOrElse(Json.obj())).right
         } catch {
-          case t: Throwable => Left(Json.obj("error" -> "bad response from exa", "status" -> resp.status, "body" -> resp.body))
+          case _: Throwable => Left(Json.obj("error" -> "bad response from exa", "status" -> resp.status, "body" -> (resp.body: String)))
         }
       } else {
-        Left(Json.obj("error" -> "bad response from exa", "status" -> resp.status, "body" -> resp.body))
+        Left(Json.obj("error" -> "bad response from exa", "status" -> resp.status, "body" -> (resp.body: String)))
       }
     }
   }
@@ -581,7 +582,7 @@ class ExaSearchClient(api: ExaApi, options: ExaSearchOptions, id: String) extend
 // vector similarity search against the referenced embedding store. The (store, model) pair lives in the entity config
 // and is never exposed to the LLM (the tool is still named after the single, id-safe SearchEngine id, like web engines).
 class RagSearchClient(embeddingStoreId: String, embeddingModelId: String, maxResults: Int, minScore: Double, id: String) extends SearchEngineClient {
-  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
+  override def search(opts: SearchEngineSearchOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, SearchEngineResponse]] = {
     val ext = env.adminExtensions.extension[AiExtension]
     val modelClientOpt = ext.flatMap(_.states.embeddingModel(embeddingModelId)).flatMap(_.getEmbeddingModelClient())
     val storeClientOpt = ext.flatMap(_.states.embeddingStore(embeddingStoreId)).flatMap(_.getEmbeddingStoreClient())

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/weaviate_embeddingstore.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/weaviate_embeddingstore.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import com.cloud.apim.otoroshi.extensions.aigateway._
+import com.cloud.apim.otoroshi.extensions.aigateway.*
 import otoroshi.env.Env
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Logger
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
+import play.api.libs.ws.WSBodyWritables.given
 
 object WeaviateEmbeddingStoreClient {
   lazy val logger = Logger("WeaviateEmbeddingStoreClient")
@@ -30,10 +31,10 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
     }
   }
 
-  private def ensureClass()(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  private def ensureClass()(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/v1/schema/$className")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .get()
       .flatMap { resp =>
@@ -42,7 +43,7 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
         } else {
           env.Ws
             .url(s"$baseUrl/v1/schema")
-            .withHttpHeaders(headers: _*)
+            .withHttpHeaders(headers*)
             .withRequestTimeout(timeout)
             .post(Json.obj(
               "class" -> className,
@@ -56,20 +57,20 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
               if (createResp.status == 200 || createResp.status == 201) {
                 Right(())
               } else {
-                Left(Json.obj("error" -> s"Weaviate class creation error: ${createResp.status}", "body" -> createResp.body))
+                Left(Json.obj("error" -> s"Weaviate class creation error: ${createResp.status}", "body" -> (createResp.body: String)))
               }
             }
         }
       }
   }
 
-  override def add(options: EmbeddingAddOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def add(options: EmbeddingAddOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     ensureClass().flatMap {
       case Left(err) => Left(err).vfuture
       case Right(_) =>
         env.Ws
           .url(s"$baseUrl/v1/objects")
-          .withHttpHeaders(headers: _*)
+          .withHttpHeaders(headers*)
           .withRequestTimeout(timeout)
           .post(Json.obj(
             "class" -> className,
@@ -87,28 +88,28 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
               // Object already exists, update it
               Right(())
             } else {
-              Left(Json.obj("error" -> s"Weaviate add error: ${resp.status}", "body" -> resp.body))
+              Left(Json.obj("error" -> s"Weaviate add error: ${resp.status}", "body" -> (resp.body: String)))
             }
           }
     }
   }
 
-  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
+  override def remove(options: EmbeddingRemoveOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Unit]] = {
     env.Ws
       .url(s"$baseUrl/v1/objects/$className/${options.id}")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .delete()
       .map { resp =>
         if (resp.status == 204 || resp.status == 404) {
           Right(())
         } else {
-          Left(Json.obj("error" -> s"Weaviate delete error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Weaviate delete error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }
 
-  override def search(options: EmbeddingSearchOptions, raw: JsObject)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
+  override def search(options: EmbeddingSearchOptions, raw: JsObject)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingSearchResponse]] = {
     val graphql = Json.obj(
       "query" ->
         s"""{
@@ -130,7 +131,7 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
     )
     env.Ws
       .url(s"$baseUrl/v1/graphql")
-      .withHttpHeaders(headers: _*)
+      .withHttpHeaders(headers*)
       .withRequestTimeout(timeout)
       .post(graphql)
       .map { resp =>
@@ -150,7 +151,7 @@ class WeaviateEmbeddingStoreClient(val config: JsObject, _storeId: String) exten
           }
           Right(EmbeddingSearchResponse(matches))
         } else {
-          Left(Json.obj("error" -> s"Weaviate search error: ${resp.status}", "body" -> resp.body))
+          Left(Json.obj("error" -> s"Weaviate search error: ${resp.status}", "body" -> (resp.body: String)))
         }
       }
   }

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/x.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/providers/x.scala
@@ -1,14 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.providers
 
-import akka.stream.scaladsl._
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
-import com.cloud.apim.otoroshi.extensions.aigateway.entities._
+import org.apache.pekko.stream.scaladsl.*
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.*
 import otoroshi.env.Env
 import otoroshi.utils.TypedMap
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 import play.api.libs.ws.WSResponse
+import play.api.libs.ws.WSBodyWritables.given
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -23,9 +24,9 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
   val supportsStreaming: Boolean = true
   override def supportsCompletion: Boolean = false
 
-  def rawCall(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawCall(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logCall("X.ai", method, url, body)(env)
+    ProviderHelpers.logCall("X.ai", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -45,9 +46,9 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
   }
 
   /** raw streamed POST, used by the native /responses path */
-  def rawStream(method: String, path: String, body: Option[JsValue])(implicit ec: ExecutionContext): Future[WSResponse] = {
+  def rawStream(method: String, path: String, body: Option[JsValue])(using ec: ExecutionContext): Future[WSResponse] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("X.ai", method, url, body)(env)
+    ProviderHelpers.logStream("X.ai", method, url, body)(using env)
     env.Ws
       .url(url)
       .withHttpHeaders(
@@ -63,14 +64,14 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
       .stream()
   }
 
-  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
+  override def call(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
     rawCall(method, path, body).map(r => ProviderHelpers.wrapResponse("X.ai", r, env) { resp =>
       acc.updateOpenai(resp.json.select("usage").asOpt[JsObject])
-      OpenAiApiResponse(resp.status, resp.headers.mapValues(_.last), resp.json)
+      OpenAiApiResponse(resp.status, resp.headers.view.mapValues(_.last).toMap, resp.json)
     })
   }
 
-  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
+  override def callWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, OpenAiApiResponse]] = {
     if (currentCallCounter >= maxCalls) {
       return call(method, path, body, acc)
     }
@@ -84,7 +85,7 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
             case Some(body) => {
               val messages = body.select("messages").asOpt[Seq[JsObject]].getOrElse(Seq.empty) //.map(v => v.flatMap(o => ChatMessage.format.reads(o).asOpt)).getOrElse(Seq.empty)
               val toolCalls = resp.toolCalls
-              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "xai", attrs, nameToFunction)(ec, env)
+              LlmFunctions.callToolsOpenai(toolCalls.map(tc => GenericApiResponseChoiceMessageToolCall(tc.raw)), mcpConnectors, "xai", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -101,9 +102,9 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
     }
   }
 
-  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def stream(method: String, path: String, body: Option[JsValue], acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     val url = s"${baseUrl}${path}"
-    ProviderHelpers.logStream("X.ai", method, url, body)(env)
+    ProviderHelpers.logStream("X.ai", method, url, body)(using env)
     env.Ws
       .url(s"${baseUrl}${path}")
       .withHttpHeaders(
@@ -138,7 +139,7 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
       })
   }
 
-  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(implicit ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = {
+  override def streamWithToolSupport(method: String, path: String, body: Option[JsValue], mcpConnectors: Seq[String], attrs: TypedMap, nameToFunction: Map[String, String], maxCalls: Int, currentCallCounter: Int, acc: UsageAccumulator)(using ec: ExecutionContext): Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = {
     if (currentCallCounter >= maxCalls) {
       return stream(method, path, body, acc)
     }
@@ -151,12 +152,11 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
           var isToolCallEnded = false
           var toolCalls: Seq[OpenAiChatResponseChunkChoiceDeltaToolCall] = Seq.empty
           var toolCallArgs: scala.collection.mutable.ArraySeq[String] = scala.collection.mutable.ArraySeq.empty
-          var toolCallUsage: OpenAiChatResponseChunkUsage = null
           val newSource = res._1.flatMapConcat { chunk =>
             if (!isToolCall && chunk.choices.exists(_.delta.exists(_.tool_calls.nonEmpty))) {
               isToolCall = true
               toolCalls = chunk.choices.head.delta.head.tool_calls
-              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => ""): _*)
+              toolCallArgs = scala.collection.mutable.ArraySeq((0 to toolCallArgs.size).map(_ => "")*)
               Source.empty
             } else if (isToolCall && !isToolCallEnded) {
               if (chunk.choices.head.finish_reason.contains("tool_calls")) {
@@ -175,12 +175,11 @@ class XAiApi(baseUrl: String = XAiApi.baseUrl, token: String, timeout: FiniteDur
                 }}
               Source.empty
             } else if (isToolCall && isToolCallEnded) {
-              toolCallUsage = chunk.usage.get
               val calls = toolCalls.zipWithIndex.map {
                 case (toolCall, idx) =>
                   GenericApiResponseChoiceMessageToolCall(toolCall.raw.asObject.deepMerge(Json.obj("function" -> Json.obj("arguments" -> toolCallArgs(idx)))))
               }
-              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, _], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "xai", attrs, nameToFunction)(ec, env)
+              val a: Future[Either[JsValue, (Source[OpenAiChatResponseChunk, ?], WSResponse)]] = LlmFunctions.callToolsOpenai(calls, mcpConnectors, "xai", attrs, nameToFunction)(using ec, env)
                 .flatMap { callResps =>
                   // val newMessages: Seq[JsValue] = messages.map(_.json) ++ callResps
                   val newMessages: Seq[JsValue] = messages ++ callResps
@@ -325,12 +324,10 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
     mcpExcludeFunctions = options.mcpExcludeFunctions,
     maxFunctionCalls = options.maxFunctionCalls,
   )
-  override protected def responsesRawCall(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/v1/responses", body.some)
-  override protected def responsesRawStream(body: JsValue)(implicit ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
+  override protected def responsesRawCall(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawCall("POST", "/v1/responses", body.some)
+  override protected def responsesRawStream(body: JsValue)(using ec: ExecutionContext, env: Env): Future[WSResponse] = api.rawStream("POST", "/v1/responses", (body.asObject ++ Json.obj("stream" -> true)).some)
 
   override def transformOpenAIInputBodyToProviderInputBody(inputBody: JsObject): JsObject = {
-    val model = inputBody.select("model").asOptString.orElse(computeModel(inputBody)).getOrElse("--")
-    val reasoningEffort = inputBody.select("reasoningEffort").asOptString.orElse(inputBody.select("reasoning_effort").asOptString)
     (inputBody - "reasoningEffort" - "reasoning_effort")
       //.applyOnWithOpt(reasoningEffort) {
       //  case (obj, r) if model.startsWith("grok-4") && model.contains("reasoning") && !model.contains("non-reasoning") =>
@@ -340,7 +337,7 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
       //}
   }
 
-  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, _]]] = {
+  override def stream(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, Source[ChatResponseChunk, ?]]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -390,7 +387,6 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
                   val newArr = arr ++ Seq(slug)
                   obj ++ Json.obj("ai" -> newArr)
                 }
-                case Some(other) => other
                 case None => Json.obj("ai" -> Seq(slug))
               }
             }
@@ -428,7 +424,7 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
     }
   }
 
-  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def call(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -474,7 +470,6 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -486,7 +481,7 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
     }
   }
 
-  override def listModels(raw: Boolean, attrs: TypedMap)(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  override def listModels(raw: Boolean, attrs: TypedMap)(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/v1/models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("data").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -496,7 +491,7 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
     }
   }
 
-  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
+  override def completion(prompt: ChatPrompt, attrs: TypedMap, originalBody: JsValue)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ChatResponse]] = {
     val body = originalBody.asObject - "messages" - "provider" - "prompt"
     val mergedOptions = (if (options.allowConfigOverride) options.jsonForCall.deepMerge(body) else options.jsonForCall).applyOn(transformOpenAIInputBodyToProviderInputBody)
     val finalModel = mergedOptions.select("model").asOptString.orElse(computeModel(mergedOptions)).getOrElse("--")
@@ -534,7 +529,6 @@ class XAiChatClient(val api: XAiApi, val options: XAiChatClientOptions, id: Stri
           val newArr = arr ++ Seq(slug)
           obj ++ Json.obj("ai" -> newArr)
         }
-        case Some(other) => other
         case None => Json.obj("ai" -> Seq(slug))
       }
       val messages = resp.body.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty).map { obj =>
@@ -556,7 +550,7 @@ object XAiEmbeddingModelClientOptions {
 
 class XAiEmbeddingModelClient(val api: XAiApi, val options: XAiEmbeddingModelClientOptions, id: String) extends EmbeddingModelClient {
 
-  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
+  override def embed(opts: EmbeddingClientInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, EmbeddingResponse]] = {
     val finalModel: String = opts.model.getOrElse(options.model)
     api.rawCall("POST", "/v1/embeddings", (options.raw ++ Json.obj("input" -> opts.input, "model" -> finalModel)).some).map { resp =>
       if (resp.status == 200) {
@@ -591,7 +585,7 @@ object XAiImageModelClientOptions {
 
 class XAiImageModelClient(val api: XAiApi, val genOptions: XAiImageModelClientOptions, id: String) extends ImageModelClient {
 
-  def listImagesGenModels()(implicit ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
+  def listImagesGenModels()(using ec: ExecutionContext): Future[Either[JsValue, List[String]]] = {
     api.rawCall("GET", "/v1/image-generation-models", None).map { resp =>
       if (resp.status == 200) {
         Right(resp.json.select("models").as[List[JsObject]].map(obj => obj.select("id").asString))
@@ -604,7 +598,7 @@ class XAiImageModelClient(val api: XAiApi, val genOptions: XAiImageModelClientOp
   override def supportsGeneration: Boolean = genOptions.enabled
   override def supportsEdit: Boolean = false
 
-  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(implicit ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
+  override def generate(opts: ImageModelClientGenerationInputOptions, rawBody: JsObject, attrs: TypedMap)(using ec: ExecutionContext, env: Env): Future[Either[JsValue, ImagesGenResponse]] = {
     val finalModel: String = opts.model.orElse(genOptions.model).getOrElse("grok-2-image")
     val body = Json.obj(
         "prompt" -> opts.prompt,
@@ -616,7 +610,7 @@ class XAiImageModelClient(val api: XAiApi, val genOptions: XAiImageModelClientOp
 
     api.rawCall("POST", "/images/generations", body.some).map { resp =>
       if (resp.status == 200) {
-        val headers = resp.headers.mapValues(_.last)
+        val headers = resp.headers.view.mapValues(_.last).toMap
         Right(ImagesGenResponse(
           created = resp.json.select("created").asOpt[Long].getOrElse(-1L),
           images = resp.json.select("data").as[Seq[JsObject]].map(o => ImagesGen(o.select("b64_json").asOpt[String], o.select("revised_prompt").asOpt[String], o.select("url").asOpt[String])),

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/workflowhelper.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/workflowhelper.scala
@@ -1,6 +1,5 @@
 package otoroshi.next.workflow
 
-import otoroshi.env.Env
 
 object WorkflowHelper {
   def getWorkflow(ext: WorkflowAdminExtension, ref: String): Option[Workflow] = {

--- a/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/workflows.scala
+++ b/src/main/scala/com/cloud/apim/otoroshi/extensions/aigateway/workflows.scala
@@ -1,15 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway
 
-import akka.stream.scaladsl.FileIO
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway.agents._
+import org.apache.pekko.stream.scaladsl.FileIO
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.agents.*
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{GuardrailResult, Guardrails}
 import com.cloud.apim.otoroshi.extensions.aigateway.guardrails.{PlaceholderAllocator, RampartEngine, RampartPiiGuardrail}
 import otoroshi.env.Env
-import otoroshi.next.workflow._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.workflow.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.extensions.aigateway.AiExtension
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.io.File
 import java.nio.file.Files
@@ -201,7 +201,7 @@ class AgentFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val agent = AgentConfig.from(args)
     val rcfg = AgentRunConfig.from(args.select("run_config").asOpt[JsObject].getOrElse(Json.obj()))
     val input: AgentInput = args.select("input")
@@ -209,7 +209,7 @@ class AgentFunction extends WorkflowFunction {
       .map(v => WorkflowOperator.processOperators(v, wfr, env))
       .map {
         case JsString(str) => AgentInput.from(str)
-        case JsArray(seq) => AgentInput(seq.map(v => ChatMessage.inputJson(v.asObject)))
+        case JsArray(seq) => AgentInput(seq.toSeq.map(v => ChatMessage.inputJson(v.asObject)))
         case obj @ JsObject(_) => AgentInput(Seq(ChatMessage.inputJson(obj)))
         case _ => AgentInput.empty
       }
@@ -282,7 +282,7 @@ class MemoryAddMessagesFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -354,7 +354,7 @@ class MemoryClearMessagesFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -428,7 +428,7 @@ class MemoryGetMessagesFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -496,7 +496,7 @@ class GuardrailCallFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val kind = args.select("kind").asString
     val config = args.select("config").asOpt[JsObject].getOrElse(Json.obj())
     val messages: Seq[ChatMessage] = args.select("input").asOptString match {
@@ -558,7 +558,7 @@ class RampartRedactFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     args.select("input").asOptString match {
       case None => WorkflowError("missing 'input' string", Some(Json.obj()), None).leftf
       case Some(text) =>
@@ -655,7 +655,7 @@ class VectorStoreAddFunction extends WorkflowFunction {
     )
   ))
 
-  override def call(args: JsObject)(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+  override def call(args: JsObject)(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -730,7 +730,7 @@ class VectorStoreRemoveFunction extends WorkflowFunction {
     )
   ))
 
-  override def call(args: JsObject)(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+  override def call(args: JsObject)(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -813,7 +813,7 @@ class VectorStoreSearchFunction extends WorkflowFunction {
     )
   ))
 
-  override def call(args: JsObject)(implicit env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
+  override def call(args: JsObject)(using env: Env, ec: ExecutionContext): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -893,7 +893,7 @@ class ModerationCallFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -977,7 +977,7 @@ class GenerateVideoFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -1055,7 +1055,7 @@ class CallMcpFunctionFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val function = args.select("function").asString
     val arguments = args.select("arguments").asOpt[JsObject].map(_.stringify)
@@ -1112,7 +1112,7 @@ class CallA2aAgentFunction extends WorkflowFunction {
     "args" -> Json.obj("connector" -> "a2a-connector_xxx", "skill" -> "main", "message" -> "Plan a route from Paris to Lyon")
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val connectorId = args.select("connector").asString
     val skill = args.select("skill").asOpt[String].getOrElse("")
     val message = args.select("message").asOpt[String].orElse(args.select("message").asOpt[JsObject].map(_.stringify)).getOrElse("")
@@ -1182,7 +1182,7 @@ class CallToolFunctionFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val arguments = args.select("arguments").asOpt[JsObject].map(_.stringify)
       .orElse(args.select("arguments").asOpt[JsArray].map(_.stringify))
@@ -1276,7 +1276,7 @@ class GenerateImageFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -1365,7 +1365,7 @@ class ComputeEmbeddingFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -1461,7 +1461,7 @@ class LlmCallFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider  = args.select("provider").asString
     val openai  = args.select("openai_format").asOptBoolean.getOrElse(true)
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
@@ -1574,7 +1574,7 @@ class AudioTtsFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider  = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val base64Encode = args.select("encode_base64").asOpt[Boolean].getOrElse(false)
@@ -1586,11 +1586,11 @@ class AudioTtsFunction extends WorkflowFunction {
         case None => WorkflowError(s"unable to instantiate client for audio provider", Some(Json.obj("provider_id" -> provider.id)), None).leftf
         case Some(client) => client.textToSpeech(AudioModelClientTextToSpeechInputOptions.format.reads(payload).get, payload, wfr.attrs).flatMap {
           case Left(error) => WorkflowError(s"error while calling audio model", Some(error.asOpt[JsObject].getOrElse(Json.obj("error" -> error))), None).leftf
-          case Right(response) if base64Encode => response._1.runFold(ByteString.empty)(_ ++ _)(env.otoroshiMaterializer).map { bs =>
+          case Right(response) if base64Encode => response._1.runFold(ByteString.empty)(_ ++ _)(using env.otoroshiMaterializer).map { bs =>
             Json.obj("content_type" -> response._2, "base64" -> bs.encodeBase64.utf8String).right
           }
           case Right(response) =>
-            response._1.runWith(FileIO.toPath(fileDest.toPath))(env.otoroshiMaterializer).map { res =>
+            response._1.runWith(FileIO.toPath(fileDest.toPath))(using env.otoroshiMaterializer).map { _ =>
               Json.obj("content_type" -> response._2, "file_out" -> fileDest.getAbsolutePath).right
             }
         }
@@ -1672,7 +1672,7 @@ class AudioSttFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider  = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val base64Decode = args.select("decode_base64").asOpt[Boolean].getOrElse(false)
@@ -1774,7 +1774,7 @@ class OcrCallFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider  = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val fileIn = args.select("file_in").asOpt[String]
@@ -1884,7 +1884,7 @@ class SearchEngineSearchFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     val provider  = args.select("provider").asString
     val payload = args.select("payload").asOpt[JsObject].getOrElse(Json.obj())
     val extension = env.adminExtensions.extension[AiExtension].get
@@ -1978,7 +1978,7 @@ class ContentToMarkdownFunction extends WorkflowFunction {
     )
   ))
 
-  override def callWithRun(args: JsObject)(implicit env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
+  override def callWithRun(args: JsObject)(using env: Env, ec: ExecutionContext, wfr: WorkflowRun): Future[Either[WorkflowError, JsValue]] = {
     if (!KreuzbergHelper.canExecuteKreuzberg) {
       return WorkflowError(KreuzbergHelper.errorMsg, None, None).leftf
     }

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/domains/providers.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/domains/providers.scala
@@ -10,12 +10,12 @@ import scala.concurrent.duration.DurationInt
 
 object LlmProviderUtils extends Assertions {
 
-  def createProvider(client: OtoroshiClient)(provider: AiProvider)(implicit ec: ExecutionContext) = {
+  def createProvider(client: OtoroshiClient)(provider: AiProvider)(using ec: ExecutionContext) = {
     val providerRes = client.forLlmEntity("providers").createEntity(provider).awaitf(10.seconds)
     assert(providerRes.created, s"[${provider.provider}] provider has not been created")
   }
 
-  def upsertProvider(client: OtoroshiClient)(provider: AiProvider)(implicit ec: ExecutionContext) = {
+  def upsertProvider(client: OtoroshiClient)(provider: AiProvider)(using ec: ExecutionContext) = {
     val providerRes = client.forLlmEntity("providers").upsertEntity(provider).awaitf(10.seconds)
     assert(providerRes.createdOrUpdated, s"[${provider.provider}] provider has not been created/updated")
   }

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/a2a.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/a2a.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.ChatMessageContent
-import com.cloud.apim.otoroshi.extensions.aigateway.a2a._
+import com.cloud.apim.otoroshi.extensions.aigateway.a2a.*
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{A2AConnector, A2AConnectorAuth, A2AServer, A2AServerBackend, A2AServerCard, A2ASkillConfig, AnthropicApiResponseChoiceMessageToolCall, GenericApiResponseChoiceMessageToolCall}
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.A2ASupportServer
-import play.api.libs.json._
+import play.api.libs.json.*
 
 // Pure unit tests for the A2A v1.0 wire models (no running server required).
 class A2ASuite extends munit.FunSuite {

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/auditing.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/auditing.scala
@@ -1,12 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
-import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, CacheSettings}
-import com.google.common.base.Charsets
-import otoroshi.events.DataExporter
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.models.{DataExporterConfig, DataExporterConfigFiltering, DataExporterConfigTypeWebhook, EntityLocation, Webhook}
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.OpenAiCompatProxy
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
@@ -134,7 +132,7 @@ class AuditingSuite extends LlmExtensionOneOtoroshiServerPerSuite {
       ))).awaitf(30.seconds)
     }
 
-    for (i <- 0 until 20) {
+    for (_ <- 0 until 20) {
       val res = call("llama3.2")
       assertEquals(res.status, 200, "status should be 200")
     }

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/cache.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/cache.scala
@@ -3,8 +3,8 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, CacheSettings}
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.OpenAiCompatProxy
 import play.api.libs.json.Json
 import reactor.core.publisher.Mono

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/context.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/context.scala
@@ -3,8 +3,8 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, ContextSettings, PromptContext}
 import com.cloud.apim.otoroshi.extensions.aigateway.{LlmExtensionOneOtoroshiServerPerSuite, LlmProviders}
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.OpenAiCompatProxy
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.libs.ws.WSResponse
@@ -21,7 +21,7 @@ class ProviderContextSuite extends LlmExtensionOneOtoroshiServerPerSuite {
   val (ollama1Port, _) = createTestServerWithRoutes("ollama1", routes => routes.post("/api/chat", (req, response) => {
     req.receive().retain().asString().flatMap { body =>
       val json = body.parseJson
-      println("____received", json.select("context").asOpt[JsValue])
+      println(("____received", json.select("context").asOpt[JsValue]))
       val messages = json.select("messages").as[Seq[JsObject]]
       responses.put("latest", messages)
       // println("received: -----------------------------------" + json.prettify)

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/filecontentparts.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/filecontentparts.scala
@@ -1,8 +1,8 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.{ChatMessageContent, ChatMessageContentFlavor, InputChatMessage}
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json._
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.*
 
 // Pure unit tests for file content parts: openai `file` (chat/completions) and `input_file` (responses)
 // shapes must be parsed and then serialized with the right flavor for the target provider.

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/filecontentpartsproxies.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/filecontentpartsproxies.scala
@@ -1,11 +1,11 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{OpenAiCompatProxy, OpenAiResponsesProxy, OpenResponseCompatProxy}
 import play.api.libs.json.{JsObject, JsValue, Json}
 import reactor.core.publisher.Mono

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/guardrails.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/guardrails.scala
@@ -5,7 +5,7 @@ import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{GuardrailItem, G
 import com.cloud.apim.otoroshi.extensions.aigateway.domains.LlmProviderUtils
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmToolFunction}
 import otoroshi.models.WasmPlugin
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.Json
 import reactor.core.publisher.Mono
 
@@ -130,7 +130,7 @@ class QuickJsGuardrailSuite extends LlmExtensionOneOtoroshiServerPerSuite {
       description = "This plugin provides the runtime for the wasm backed LLM tool calls",
       config = LlmToolFunction.wasmConfig
     ).json.stringify.byteString
-    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
+    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(using otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
     await(1300.millis)
 
     {

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/jlama.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/jlama.scala
@@ -5,7 +5,6 @@ import com.github.tjake.jlama.safetensors.DType
 import com.github.tjake.jlama.safetensors.prompt.PromptContext
 import com.github.tjake.jlama.util.Downloader
 
-import java.lang.management.ManagementFactory
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiConsumer
@@ -36,7 +35,7 @@ class JlamaSuite extends munit.FunSuite {
       println("=========================================================")
       println(s"[$i] Start")
       val counter = new AtomicInteger(0)
-      val r = m.generate(UUID.randomUUID(), ctx, 0.8f, 500, new BiConsumer[java.lang.String, java.lang.Float] {
+      val _ = m.generate(UUID.randomUUID(), ctx, 0.8f, 500, new BiConsumer[java.lang.String, java.lang.Float] {
         override def accept(t: java.lang.String, u: java.lang.Float): Unit = {
           counter.incrementAndGet()
           //println(s"on: ${t} - ${u}")

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/loadbalancing.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/loadbalancing.scala
@@ -3,7 +3,7 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
+import otoroshi.next.models.*
 import otoroshi.utils.syntax.implicits.BetterFuture
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.OpenAiCompatProxy
 import play.api.libs.json.Json
@@ -186,11 +186,9 @@ class LoadBalancerSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         ))
       ))).awaitf(30.seconds)
     }
-    val counterFoo = new AtomicInteger(0)
-    val counterBar = new AtomicInteger(0)
     val counterOllama1 = new AtomicInteger(0)
     val counterOllama2 = new AtomicInteger(0)
-    for (i <- 0 until 20) {
+    for (_ <- 0 until 20) {
       val res = call("foo")
       val body = res.body
       assertEquals(res.status, 200, "status should be 200")

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/mcp.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/mcp.scala
@@ -1,10 +1,10 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
-import com.cloud.apim.otoroshi.extensions.aigateway.entities._
+import com.cloud.apim.otoroshi.extensions.aigateway.entities.*
 import otoroshi.models.{EntityLocation, WasmPlugin}
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{McpRespEndpoint, McpSseEndpoint, McpWebsocketEndpoint, OpenAiCompatProxy}
 import play.api.libs.json.{JsObject, Json}
 import reactor.core.publisher.Mono
@@ -343,7 +343,7 @@ class McpSuite extends LlmExtensionOneOtoroshiServerPerSuite {
     /////////                                  test                                                          ///////////
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     var messages = Seq.empty[JsObject]
-    val (pushRef, cancel) = client.ws(s"ws://test.oto.tools:${port}/ws") { ref =>
+    val (pushRef, cancel) = client.ws(s"ws://test.oto.tools:${port}/ws") { _ =>
       (message: String) => {
         messages = messages :+ message.parseJson.asObject
       }
@@ -543,7 +543,7 @@ class McpSuite extends LlmExtensionOneOtoroshiServerPerSuite {
       description = "This plugin provides the runtime for the wasm backed LLM tool calls",
       config = LlmToolFunction.wasmConfig
     ).json.stringify.byteString
-    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
+    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(using otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
     await(2.seconds)
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     /////////                                  test                                                          ///////////
@@ -633,7 +633,7 @@ class McpSuite extends LlmExtensionOneOtoroshiServerPerSuite {
       description = "This plugin provides the runtime for the wasm backed LLM tool calls",
       config = LlmToolFunction.wasmConfig
     ).json.stringify.byteString
-    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
+    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(using otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
     await(2.seconds)
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     /////////                                  test                                                          ///////////

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/mcpzerotrust.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/mcpzerotrust.scala
@@ -1,8 +1,8 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.decorators.GuardrailItem
-import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{McpProxyEndpointConfig, McpRedaction, McpRedactionRule, McpToolPinning, McpZeroTrustConfig, PinVerdict}
-import play.api.libs.json.{JsArray, JsNull, JsNumber, JsObject, JsString, Json}
+import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{McpProxyEndpointConfig, McpRedaction, McpRedactionRule, McpToolPinning, McpZeroTrustConfig}
+import play.api.libs.json.{JsArray, JsObject, JsString, Json}
 
 // Pure unit tests for the Zero-Trust MCP security logic that does NOT require a booted Otoroshi:
 //   - tool fingerprinting / canonicalization (anti-rug-pull, sub-feature A)

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/models.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/models.scala
@@ -3,8 +3,8 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, ModelSettings}
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{OpenAiCompatModels, OpenAiCompatProxy}
 import play.api.libs.json.{JsObject, Json}
 
@@ -65,7 +65,7 @@ class ProviderModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
 
     {
       val r = client.call("GET", s"http://test.oto.tools:${port}/models", Map.empty, None).awaitf(30.seconds)
-      val models = r.body.parseJson.select("data").as[Seq[JsObject]]
+      val models = (r.body: String).parseJson.select("data").as[Seq[JsObject]]
       println(s"models: ${models.size}")
       assertEquals(models.size, 13)
     }
@@ -76,7 +76,7 @@ class ProviderModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         .awaitf(10.seconds)
       await(2.seconds)
       val r = client.call("GET", s"http://test.oto.tools:${port}/models", Map.empty, None).awaitf(30.seconds)
-      val models = r.body.parseJson.select("data").as[Seq[JsObject]]
+      val models = (r.body: String).parseJson.select("data").as[Seq[JsObject]]
       println(s"models: ${models.size}")
       assertEquals(models.size, 1)
     }
@@ -87,7 +87,7 @@ class ProviderModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         .awaitf(10.seconds)
       await(2.seconds)
       val r = client.call("GET", s"http://test.oto.tools:${port}/models", Map.empty, None).awaitf(30.seconds)
-      val models = r.body.parseJson.select("data").as[Seq[JsObject]]
+      val models = (r.body: String).parseJson.select("data").as[Seq[JsObject]]
       println(s"models: ${models.size}")
       assertEquals(models.size, 2)
     }
@@ -98,7 +98,7 @@ class ProviderModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         .awaitf(10.seconds)
       await(2.seconds)
       val r = client.call("GET", s"http://test.oto.tools:${port}/models", Map.empty, None).awaitf(30.seconds)
-      val models = r.body.parseJson.select("data").as[Seq[JsObject]]
+      val models = (r.body: String).parseJson.select("data").as[Seq[JsObject]]
       println(s"models: ${models.size}")
       assertEquals(models.size, 7)
     }

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/openapimcp.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/openapimcp.scala
@@ -3,7 +3,7 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.assistant.logic.Catalog
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.McpSupport
 import com.cloud.apim.otoroshi.extensions.aigateway.mcp.{OpenApiMcpClient, OpenApiSchema}
-import play.api.libs.json._
+import play.api.libs.json.*
 
 /**
  * Pure unit tests (no Otoroshi server) for the OpenAPI MCP connector building blocks:

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/providers.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/providers.scala
@@ -1,23 +1,25 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.cloud.apim.otoroshi.extensions.aigateway.{LLmExtensionSuite, LlmExtensionOneOtoroshiServerPerSuite, LlmProviders, OtoroshiClient, TestLlmProviderSettings}
 import com.cloud.apim.otoroshi.extensions.aigateway.domains.LlmProviderUtils
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, LlmToolFunction, LlmToolFunctionBackend, LlmToolFunctionBackendKind, LlmToolFunctionBackendOptions}
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.OVHAiEndpointsApi
 import otoroshi.api.Otoroshi
 import otoroshi.models.WasmPlugin
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{OpenAiCompatModels, OpenAiCompatProxy}
 import play.api.libs.json.{JsObject, Json}
 
 import java.util.UUID
+import scala.compiletime.uninitialized
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import otoroshi.env.Env
 
 class ProvidersSuite extends LLmExtensionSuite {
 
-  def testChatCompletionWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testChatCompletionWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val token = sys.env(provider.envToken)
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -104,7 +106,7 @@ class ProvidersSuite extends LLmExtensionSuite {
     await(1300.millis)
   }
 
-  def testChatCompletionStreamingWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testChatCompletionStreamingWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val token = sys.env(provider.envToken)
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -190,7 +192,7 @@ class ProvidersSuite extends LLmExtensionSuite {
     await(1300.millis)
   }
 
-  def testCompletionWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testCompletionWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val port = client.port
     val token = sys.env(provider.envToken)
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -272,7 +274,7 @@ class ProvidersSuite extends LLmExtensionSuite {
     await(1300.millis)
   }
 
-  def testModelsWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testModelsWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
 
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -352,7 +354,7 @@ class ProvidersSuite extends LLmExtensionSuite {
     await(1300.millis)
   }
 
-  def testToolsCallWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testToolsCallWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val token = sys.env(provider.envToken)
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -456,7 +458,7 @@ class ProvidersSuite extends LLmExtensionSuite {
       description = "This plugin provides the runtime for the wasm backed LLM tool calls",
       config = LlmToolFunction.wasmConfig
     ).json.stringify.byteString
-    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
+    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(using otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
     await(1300.millis)
     val resp = client.call("POST", s"http://${provider.name}.oto.tools:${port}/chat", Map.empty, Some(Json.parse(
       s"""{
@@ -484,7 +486,7 @@ class ProvidersSuite extends LLmExtensionSuite {
     await(1300.millis)
   }
 
-  def testToolsCallStreamWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testToolsCallStreamWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val token = sys.env(provider.envToken)
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -588,7 +590,7 @@ class ProvidersSuite extends LLmExtensionSuite {
       description = "This plugin provides the runtime for the wasm backed LLM tool calls",
       config = LlmToolFunction.wasmConfig
     ).json.stringify.byteString
-    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
+    otoroshi.env.datastores.rawDataStore.set(s"otoroshi:wasm-plugins:${LlmToolFunction.wasmPluginId}", payload, None)(using otoroshi.executionContext, otoroshi.env).awaitf(10.seconds)
     await(1300.millis)
     val resp = client.stream("POST", s"http://${provider.name}.oto.tools:${port}/chat?stream=true", Map.empty, Some(Json.parse(
       s"""{
@@ -619,10 +621,10 @@ class ProvidersSuite extends LLmExtensionSuite {
   }
 
   val port: Int = freePort
-  var otoroshi: Otoroshi = _
-  var client: OtoroshiClient = _
-  implicit var ec: ExecutionContext = _
-  implicit var mat: Materializer = _
+  var otoroshi: Otoroshi = uninitialized
+  var client: OtoroshiClient = uninitialized
+  implicit var ec: ExecutionContext = uninitialized
+  implicit var mat: Materializer = uninitialized
 
   override def beforeAll(): Unit = {
     otoroshi = startOtoroshiServer(port)
@@ -1218,15 +1220,15 @@ class OvhModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
 
   test("test".ignore) {
 
-    implicit val env = otoroshi.env
-    implicit val ec = otoroshi.env.otoroshiExecutionContext
+    given env: Env = otoroshi.env
+    given ec: ExecutionContext = otoroshi.env.otoroshiExecutionContext
 
     OVHAiEndpointsApi.getModelsList().flatMap {
-      case Left(err) => ().vfuture
+      case Left(_) => ().vfuture
       case Right(list) => {
         list.mapAsync { ref =>
           OVHAiEndpointsApi.getModel(ref.name).map {
-            case Left(err) => ()
+            case Left(_) => ()
             case Right(model) => {
               val r = client.call("GET", model.documentation_url, Map.empty, None).awaitf(30.seconds)
               r.body.split("\n").toSeq.filter { line =>
@@ -1340,7 +1342,7 @@ class OvhModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         )
       )
     )).awaitf(awaitFor)
-    println(resp4.status, resp4.body)
+    println((resp4.status, resp4.body))
     // val reasoning = resp.json.at("choices.0.message.reasoning_details").asOptString
     // assert(reasoning.isDefined, s"[${provider.name}] no reasoning content")
     // assert(reasoning.get.nonEmpty, s"[${provider.name}] no reasoning")
@@ -1355,10 +1357,10 @@ class OvhModelsSuite extends LlmExtensionOneOtoroshiServerPerSuite {
 class StreamingWithAuditingSuite extends LLmExtensionSuite {
 
   val port: Int = freePort
-  var otoroshi: Otoroshi = _
-  var client: OtoroshiClient = _
-  implicit var ec: ExecutionContext = _
-  implicit var mat: Materializer = _
+  var otoroshi: Otoroshi = uninitialized
+  var client: OtoroshiClient = uninitialized
+  implicit var ec: ExecutionContext = uninitialized
+  implicit var mat: Materializer = uninitialized
 
   override def beforeAll(): Unit = {
     otoroshi = startOtoroshiServer(port)
@@ -1371,7 +1373,7 @@ class StreamingWithAuditingSuite extends LLmExtensionSuite {
     otoroshi.stop()
   }
 
-  def testChatCompletionStreamingWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(implicit ec: ExecutionContext, mat: Materializer): Unit = {
+  def testChatCompletionStreamingWith(provider: TestLlmProviderSettings, client: OtoroshiClient, awaitFor: FiniteDuration)(using ec: ExecutionContext, mat: Materializer): Unit = {
     val token = sys.env(provider.envToken)
     val port = client.port
     val providerId = s"provider_${UUID.randomUUID().toString}"
@@ -1544,7 +1546,7 @@ class MistralSuite extends LlmExtensionOneOtoroshiServerPerSuite {
         )
       )
     )).awaitf(awaitFor)
-    println(resp4.status, resp4.body)
+    println((resp4.status, resp4.body))
     client.forLlmEntity("providers").deleteEntity(llmprovider)
     client.forEntity("proxy.otoroshi.io", "v1", "routes").deleteRaw(routeChatId)
     await(1300.millis)

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/resilience.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/resilience.scala
@@ -3,7 +3,7 @@ package com.cloud.apim.otoroshi.extensions.aigateway.suites
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.AiProvider
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
+import otoroshi.next.models.*
 import otoroshi.utils.syntax.implicits.BetterFuture
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.OpenAiCompatProxy
 import play.api.libs.json.Json

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/responses.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/responses.scala
@@ -5,8 +5,8 @@ import com.cloud.apim.otoroshi.extensions.aigateway.decorators.{GuardrailItem, G
 import com.cloud.apim.otoroshi.extensions.aigateway.entities.{AiProvider, ContextSettings, ModelSettings, PersistentMemory, PromptContext, SearchEngine}
 import com.cloud.apim.otoroshi.extensions.aigateway.providers.{AzureOpenAiApi, AzureOpenAiChatClient, AzureOpenAiChatClientOptions}
 import otoroshi.models.EntityLocation
-import otoroshi.next.models._
-import otoroshi.utils.syntax.implicits._
+import otoroshi.next.models.*
+import otoroshi.utils.syntax.implicits.*
 import otoroshi_plugins.com.cloud.apim.otoroshi.extensions.aigateway.plugins.{OpenAiResponsesProxy, OpenResponseCompatProxy}
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import org.reactivestreams.Publisher
@@ -14,7 +14,7 @@ import reactor.core.publisher.{Flux, Mono}
 import reactor.netty.http.server.{HttpServerRequest, HttpServerResponse}
 
 import java.util.UUID
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.DurationInt
 

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/responsesconverter.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/responsesconverter.scala
@@ -1,15 +1,15 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
-import akka.util.ByteString
-import com.cloud.apim.otoroshi.extensions.aigateway._
-import otoroshi.utils.syntax.implicits._
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import org.apache.pekko.util.ByteString
+import com.cloud.apim.otoroshi.extensions.aigateway.*
+import otoroshi.utils.syntax.implicits.*
+import play.api.libs.json.{JsObject, JsValue, Json}
 
 // Unit tests of the responses <-> chat/completions translation. The end to end behaviour is covered
 // by ResponsesSuite, this pins the conversion rules themselves.
 class OpenAiResponsesConverterSuite extends munit.FunSuite {
 
-  import OpenAiResponsesBodyConverter._
+  import OpenAiResponsesBodyConverter.*
 
   // ---- responses → chat/completions --------------------------------------------------------
 

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/test.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/suites/test.scala
@@ -1,7 +1,7 @@
 package com.cloud.apim.otoroshi.extensions.aigateway.suites
 
 import com.cloud.apim.otoroshi.extensions.aigateway.LlmExtensionOneOtoroshiServerPerSuite
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.libs.json.Json
 import reactor.core.publisher.Mono
 import reactor.netty.ByteBufFlux

--- a/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/utils.scala
+++ b/src/test/scala/com/cloud/apim/otoroshi/extensions/aigateway/utils.scala
@@ -1,24 +1,24 @@
 package com.cloud.apim.otoroshi.extensions.aigateway
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Framing, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Framing, Sink, Source}
+import org.apache.pekko.util.ByteString
 import com.typesafe.config.ConfigFactory
 import io.netty.buffer.Unpooled
 import io.netty.util.CharsetUtil
 import otoroshi.api.Otoroshi
 import otoroshi.models.Entity
-import otoroshi.utils.syntax.implicits._
+import otoroshi.utils.syntax.implicits.*
 import play.api.Configuration
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.ahc.{AhcWSClient, AhcWSClientConfig}
 import play.api.libs.ws.{WSClient, WSClientConfig, WSConfigParser, WSResponse}
+import play.api.libs.ws.WSBodyWritables.given
 import play.core.server.ServerConfig
 import reactor.core.Disposable
-import reactor.core.publisher.{Mono, Sinks}
+import reactor.core.publisher.Sinks
 import reactor.netty.DisposableServer
-import reactor.netty.http.HttpProtocol
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.server.{HttpServer, HttpServerRequest, HttpServerResponse, HttpServerRoutes}
 
@@ -26,14 +26,15 @@ import java.net.ServerSocket
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.Base64
-import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
+import scala.compiletime.uninitialized
+import scala.concurrent.duration.{Duration, DurationInt, DurationLong, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Random, Try}
 
 object Utils {
 
-  private lazy implicit val actorSystem: ActorSystem   = ActorSystem(s"test-actor-system")
-  private lazy implicit val materializer: Materializer = Materializer(actorSystem)
+  private given actorSystem: ActorSystem = ActorSystem(s"test-actor-system")
+  private given materializer: Materializer = Materializer(actorSystem)
 
   val wsClientInstance: WSClient = {
     val parser: WSConfigParser         = new WSConfigParser(
@@ -303,22 +304,22 @@ object Utils {
       config.copy(
         wsClientConfig = wsClientConfig
       )
-    )(materializer)
+    )(using materializer)
   }
 
   def await(duration: FiniteDuration): Unit = {
-    val p = Promise[Unit]
+    val p = Promise[Unit]()
     actorSystem.scheduler.scheduleOnce(duration) {
       p.trySuccess(())
-    }(actorSystem.dispatcher)
+    }(using actorSystem.dispatcher)
     Await.result(p.future, duration + 1.second)
   }
 
-  def awaitF(duration: FiniteDuration)(implicit system: ActorSystem): Future[Unit] = {
-    val p = Promise[Unit]
+  def awaitF(duration: FiniteDuration)(using system: ActorSystem): Future[Unit] = {
+    val p = Promise[Unit]()
     system.scheduler.scheduleOnce(duration) {
       p.trySuccess(())
-    }(actorSystem.dispatcher)
+    }(using actorSystem.dispatcher)
     p.future
   }
 
@@ -332,7 +333,7 @@ object Utils {
   }
 
   def startOtoroshi(port: Int = freePort): Otoroshi = {
-    implicit val ec = actorSystem.dispatcher
+    given ec: ExecutionContext = actorSystem.dispatcher
     val cfg = s"""
                  |include "application.conf"
                  |
@@ -370,7 +371,7 @@ object Utils {
           .withRequestTimeout(1.second)
           .get()
           .map(r => r.status)
-          .recover { case e =>
+          .recover { case _ =>
             0
           }
       }
@@ -394,7 +395,7 @@ case class OtoroshiClientStreamedResponse(resp: WSResponse, chunks: Seq[JsValue]
   def created: Boolean = resp.status == 201
   def success: Boolean = resp.status > 199 && resp.status < 300
   def status: Int = resp.status
-  def headers: Map[String, String] = resp.headers.mapValues(_.last)
+  def headers: Map[String, String] = resp.headers.view.mapValues(_.last).toMap
   def state: String = s"${status} - ${headers}"
   lazy val message: String = chunks.map { chunk =>
     val choices = chunk.select("choices").asOpt[Seq[JsObject]].getOrElse(Seq.empty)
@@ -407,7 +408,7 @@ case class OtoroshiClient(port: Int, client: WSClient, ec: ExecutionContext, mat
   lazy val wsclient = HttpClient.create()
 
   def call(method: String, url: String, headers: Map[String, String], body: Option[JsValue]): Future[WSResponse] = {
-    client.url(url).withMethod(method).withHttpHeaders(headers.toSeq:_*).applyOnWithOpt(body) {
+    client.url(url).withMethod(method).withHttpHeaders(headers.toSeq*).applyOnWithOpt(body) {
       case (builder, body) => builder.withBody(body)
     }.execute()
   }
@@ -425,7 +426,7 @@ case class OtoroshiClient(port: Int, client: WSClient, ec: ExecutionContext, mat
   def noop(in: String): Unit = ()
 
   def stream(method: String, url: String, headers: Map[String, String], body: Option[JsValue], timeout: FiniteDuration = 60.seconds, handler: Function[String, Unit] = noop): Future[OtoroshiClientStreamedResponse] = {
-    client.url(url).withMethod(method).withHttpHeaders(headers.toSeq:_*).applyOnWithOpt(body){
+    client.url(url).withMethod(method).withHttpHeaders(headers.toSeq*).applyOnWithOpt(body){
       case (builder, body) => builder.withBody(body)
     }.withRequestTimeout(timeout).stream().flatMap { resp =>
       resp.bodyAsSource
@@ -444,11 +445,11 @@ case class OtoroshiClient(port: Int, client: WSClient, ec: ExecutionContext, mat
         .filterNot(_.startsWith("[DONE]"))
         .map(_.parseJson)
         .takeWithin((timeout.toMillis - 10).millis)
-        .runWith(Sink.seq)(mat)
+        .runWith(Sink.seq)(using mat)
         .map { chunks =>
           OtoroshiClientStreamedResponse(resp, chunks)
-        }(ec)
-    }(ec)
+        }(using ec)
+    }(using ec)
   }
 
   def forEntity(group: String, version: String, pluralName: String): OtoroshiEntityClient = {
@@ -462,11 +463,11 @@ case class OtoroshiClient(port: Int, client: WSClient, ec: ExecutionContext, mat
 
 case class OtoroshiEntityClient(client: OtoroshiClient, group: String, version: String, pluralName: String) {
   def raw_call(method: String, url: String, headers: Map[String, String], body: Option[JsValue]): Future[OtoroshiResponse] = {
-    client.client.url(url).withMethod(method).withHttpHeaders(headers.toSeq:_*).applyOnWithOpt(body){
+    client.client.url(url).withMethod(method).withHttpHeaders(headers.toSeq*).applyOnWithOpt(body){
       case (builder, body) => builder.withBody(body)
     }.execute().map { resp =>
       OtoroshiResponse(client, group, pluralName, method, url, headers, body, resp)
-    }(client.ec)
+    }(using client.ec)
   }
 
   def call(method: String, id: Option[String] = None, body: Option[JsValue] = None): Future[OtoroshiResponse] = {
@@ -512,7 +513,7 @@ case class OtoroshiResponse(client: OtoroshiClient, group: String, pluralName: S
   def createdOrUpdated: Boolean = resp.status == 201 || resp.status == 200
   def success: Boolean = resp.status > 199 && resp.status < 300
   def status: Int = resp.status
-  def headers: Map[String, String] = resp.headers.mapValues(_.last)
+  def headers: Map[String, String] = resp.headers.view.mapValues(_.last).toMap
   def body: ByteString = resp.bodyAsBytes
   def bodyJson: JsValue = resp.json
   def state: String = s"${status} - ${resp.body}"
@@ -520,6 +521,10 @@ case class OtoroshiResponse(client: OtoroshiClient, group: String, pluralName: S
 
 
 class LLmExtensionSuite extends munit.FunSuite {
+
+  // these suites boot a full otoroshi and script their own waits for state sync / exporter
+  // flushes, which does not fit in munit's 30s default
+  override val munitTimeout: Duration = 5.minutes
 
   private[aigateway] val testServers = scala.collection.mutable.ArraySeq.empty[(String, Int, DisposableServer)]
 
@@ -556,10 +561,10 @@ class LLmExtensionSuite extends munit.FunSuite {
 class LlmExtensionOneOtoroshiServerPerSuite extends LLmExtensionSuite {
 
   val port: Int = freePort
-  var otoroshi: Otoroshi = _
-  var client: OtoroshiClient = _
-  implicit var ec: ExecutionContext = _
-  implicit var mat: Materializer = _
+  var otoroshi: Otoroshi = uninitialized
+  var client: OtoroshiClient = uninitialized
+  implicit var ec: ExecutionContext = uninitialized
+  implicit var mat: Materializer = uninitialized
 
   override def beforeAll(): Unit = {
     otoroshi = startOtoroshiServer(port)
@@ -582,10 +587,10 @@ class LlmExtensionOneOtoroshiServerPerSuite extends LLmExtensionSuite {
 class LlmExtensionOneOtoroshiServerPerTest extends LLmExtensionSuite {
 
   val port: Int = freePort
-  var otoroshi: Otoroshi = _
-  var client: OtoroshiClient = _
-  implicit var ec: ExecutionContext = _
-  implicit var mat: Materializer = _
+  var otoroshi: Otoroshi = uninitialized
+  var client: OtoroshiClient = uninitialized
+  implicit var ec: ExecutionContext = uninitialized
+  implicit var mat: Materializer = uninitialized
 
   override def beforeEach(context: BeforeEach): Unit = {
     otoroshi = startOtoroshiServer(port)


### PR DESCRIPTION
Passe l'extension en **Scala 3.8.4 / Play 3 / Pekko**, contre **otoroshi 18.0.0-preview2**.
Même forme que les migrations déjà mergées de `otoroshi-plugin-mailer`, `otoroshi-biscuit-studio`
et `otoroshi-waf-extension`.

175 fichiers, +2580 / -2635.

## Build

| | avant | après |
|---|---|---|
| scala | 2.12.18 | 3.8.4 |
| otoroshi | 17.17.0 | 18.0.0-preview2 |
| sbt | 1.9.8 | 1.12.9 |
| sbt-assembly | 2.1.5 | 2.4.1 |
| munit | 0.7.29 | 1.0.4 |
| jackson | 2.15.3 | 2.22.2 (aligné sur `otoroshi/build.sbt`) |
| netty | 4.1.107.Final | 4.2.17.Final (aligné, + `dependencyOverrides`) |

Le fat jar n'embarque plus la stdlib scala (`assembly / assemblyPackageScala / assembleArtifact := false`) :
otoroshi fournit exactement la même. Vérifié : 0 classe `scala/collection/…` dans le jar, langchain4j /
jlama / lucene / kreuzberg / jackson toujours présents, netty / pekko / play / otoroshi absents (provided).

`java-jq` est ajouté en dépendance de test : otoroshi l'embarque comme jar *unmanaged* dans son `lib/`,
il est donc absent de son pom publié et les suites qui démarrent un vrai otoroshi ne bootaient pas sans lui.

## Migration

- `akka.*` → `org.apache.pekko.*`, `akka.stream.alpakka.s3` → `pekko.stream.connectors.s3`
- `import x._` → `import x.*`, `xs: _*` → `xs*`, `Source[ByteString, _]` → `Source[…, ?]`
- listes `(implicit …)` → clauses `using` (otoroshi 18 déclare `using` sur `preRoute` / `access` /
  `transformRequest` / `callBackend` / `call` / `callWithRun` / `run` / `redisLike` / `BasicStore`),
  `implicit val` → `given`, `implicit class … extends AnyVal` → `extension`.
  Les `implicit var` des suites restent tels quels : un `given` ne peut pas être un `var`.
- collections 2.13 : `mapValues` / `filterKeys` → `.view.….toMap`, `.toSeq` là où play-json 3 renvoie
  une `scala.collection.Seq`, `JavaConverters` → `scala.jdk.CollectionConverters`

### Ruptures d'API traversées

- **vert.x 4 → 5** : `PgPool.pool(opts, poolOptions)` n'existe plus, les pools passent par
  `PgBuilder.pool().connectingTo(…).with(…).build()` et sont typés `io.vertx.sqlclient.Pool`
- **lettuce 6 → 7** : `psetex(k, ttl, v)` → `set(k, v, SetArgs.Builder.px(ttl))`
- **pekko-connectors** : `S3.download` déprécié → `fileContent` streame `S3.getObject` avec `Keep.both`
  et retransforme une `S3Exception` `NoSuchKey` en `None` pour garder la sémantique d'origine ;
  `Source.lazily` → `Source.lazySource` ; `Multipart.toEntity()` → `toEntity`
- **play 3** : `WSBodyWritables.given` doit être importé explicitement pour `withBody`/`post`/`put`, et
  le `WSResponse.body` surchargé demande `(resp.body: String)` là où le type attendu est ouvert

## Bugs corrigés au passage

- les deux shims `ProtocolKeyword` (cache sémantique, embedding store redis) définissaient
  `override def name(): String = name`, qui **se rappelait lui-même** au lieu de renvoyer le nom de la
  commande. Le paramètre s'appelle maintenant `cmdName`.
- `scripts/run-offline-tests.sh` utilisait `...NomDeSuite`, qui n'est pas un joker `testOnly` : **17 des
  18 suites offline n'étaient jamais exécutées**. Elles le sont maintenant (`*NomDeSuite`).
- 38 `case Some(other) => other` étaient inatteignables (le `case Some(obj @ JsObject(_))` au-dessus
  couvre déjà tous les `Some`), plus un `case _` après un match exhaustif sur `JsValue`
- code mort : imports, locals, variables de pattern, une surcharge privée `computeExprAfter`, trois
  arguments par défaut jamais utilisés, un `import scala.tools.nsc.Global` résiduel, et le `var
  toolCallUsage` des cinq clients streaming openai-like (assigné depuis `chunk.usage.get`, jamais relu)

## Warnings

`sbt clean compile Test/compile assembly` → **0 erreur, 0 warning**.

`-Wunused` est scopé à `imports,privates,locals,patvars` plutôt que `all` : les traits de `models.scala`
(chat / audio / image / ocr model clients) répondent « not supported » depuis des corps par défaut qui
ignorent légitimement tous leurs arguments, et les handlers `AdminExtension*Route` doivent garder la
signature qu'otoroshi leur impose. Tout ce qui détecte du vrai code mort reste actif.

## Tests

`sh ./scripts/run-offline-tests.sh` — 18 suites, **157 tests, 156 verts**.
Un vrai otoroshi 18 démarre bien dans les suites (audit trail, cache, load balancing, MCP, A2A,
responses, guardrails…).

`munitTimeout` est passé à 5 minutes : ces suites démarrent un otoroshi complet et scriptent leurs
propres attentes (sync d'état, flush des exporters), ce qui ne tient pas dans les 30 s par défaut de munit.

Le seul échec restant est **préexistant** et sans lien avec la migration :
`McpRegistrySuite.slotPath reads mcp_path for the preset and the include head for a raw endpoint`
attend `Some("/mcp")` par défaut alors que `McpExpositionScanner.slotPath` renvoie `None`. Le test *et*
l'implémentation sont identiques au bit près à `main` — personne ne l'avait vu parce que la suite n'était
jamais lancée. À arbitrer : soit `slotPath` doit avoir un défaut `/mcp`, soit le test doit être corrigé.

Les tests qui tapent de vrais providers LLM n'ont pas été lancés.

## Restant

`documentation/docs/install.mdx` pointe encore le jar `_2.12` de la release 0.0.73 déjà publiée : le lien
est valide, il sera à mettre à jour à la prochaine release (les artefacts publiés deviennent
`otoroshi-llm-extension_3-<version>.jar`).
